### PR TITLE
First pass at block type component interface

### DIFF
--- a/colonel-kurtz/actions/block_actions.js
+++ b/colonel-kurtz/actions/block_actions.js
@@ -19,6 +19,16 @@ var BlockActions = {
       blockId: params.blockId,
       parentBlockListId: params.parentBlockListId
     })
+  },
+
+  update(params: {blockId: number; content: Object}) {
+    var { blockId, content } = params
+
+    Dispatcher.dispatch({
+      type: BlockConstants.BLOCK_UPDATE,
+      blockId: blockId,
+      content: content
+    })
   }
 
 }

--- a/colonel-kurtz/components/block_types/medium.js
+++ b/colonel-kurtz/components/block_types/medium.js
@@ -1,34 +1,65 @@
 /* @flow */
 
-var React = require('react')
-var Pure = require('mixins/pure')
+var React        = require('react')
 var MediumEditor = require('vendor/medium-editor')
+var BlockType    = require('mixins/block_type')
 
 require('vendor/medium-editor/style')
 
 var Medium = React.createClass({
 
-  shouldComponentUpdate(props) {
-    return props.content !== this.props.content
+  // Begin: Common Block Type Interface
+  //
+  // Each block type component must include the BlockType mixin and implement:
+  // - defaultContent()
+  // - renderEditor()
+  // - renderPreviewer()
+  //
+  // Block content is managed via calls to setContent(), which updates both
+  // this component's state as well as the block instance's content.
+
+  mixins: [BlockType],
+
+  defaultContent() {
+    return {
+      html: ''
+    }
   },
 
+  renderEditor() {
+    return (
+      <div className="colonel-block-content">
+        <div className="colonel-block-editor" onBlur={ this.onEditorBlur } role="textarea" aria-multiline="true" ref="editor" dangerouslySetInnerHTML={{ __html: this.state.content.html }} />
+      </div>
+    )
+  },
+
+  renderPreviewer() {
+    return (
+      <div dangerouslySetInnerHTML={{ __html: this.state.content.html }}></div>
+    )
+  },
+
+  // End: Common Block Type Interface
+
   componentDidMount() {
-    this.setState({
-      editor: new MediumEditor(this.refs.editor.getDOMNode(), this.props.options)
-    })
+    if (this.editMode()) {
+      this.setState({
+        editor: new MediumEditor(this.refs.editor.getDOMNode(), this.props.options)
+      })
+    }
   },
 
   componentWillUnmount() {
-    this.state.editor.deactivate()
+    if (this.editMode()) {
+      this.state.editor.deactivate()
+    }
   },
 
-  render(): any {
-    return (
-      <div className="colonel-block-content">
-        <div className="colonel-block-editor" role="textarea" aria-multiline="true" ref="editor" dangerouslySetInnerHTML={{ __html: this.props.content }} />
-      </div>
-    )
-  }
+  onEditorBlur() {
+    var htmlContent = { html: this.refs.editor.getDOMNode().innerHTML }
+    this.setContent(htmlContent)
+  },
 
 })
 

--- a/colonel-kurtz/components/editor_block.js
+++ b/colonel-kurtz/components/editor_block.js
@@ -4,6 +4,7 @@ var React = require('react')
 var RemoveBlockButton = require('./remove_block_button')
 var ActLikeBlockWithBlockList = require('../mixins/acts_like_block_with_block_list')
 var Medium = require('./block_types/medium')
+var AppConstants = require('constants/app_constants')
 
 var EditorBlock = React.createClass({
 
@@ -13,12 +14,16 @@ var EditorBlock = React.createClass({
     return require('./editor_block_list')
   },
 
+  updateContent(content) {
+    this.state.block.update(content)
+  },
+
   render(): any {
-    var { content, id, parentBlockListId } = this.state.block
+    var { id, parentBlockListId } = this.state.block
 
     return(
       <div className="colonel-block">
-        <Medium { ...this.state.block } />
+        <Medium mode={ AppConstants.EDIT_MODE } initialContent={ this.state.block.content } updateContent={ this.updateContent } />
 
         <div className="colonel-toolbar">
           <RemoveBlockButton blockId={ id } blockListId={ parentBlockListId } />

--- a/colonel-kurtz/components/previewer_block.js
+++ b/colonel-kurtz/components/previewer_block.js
@@ -2,6 +2,8 @@
 
 var React = require('react')
 var ActLikeBlockWithBlockList = require('../mixins/acts_like_block_with_block_list')
+var AppConstants = require('constants/app_constants')
+var Medium = require('./block_types/medium')
 
 var PreviewerBlock = React.createClass({
 
@@ -14,7 +16,7 @@ var PreviewerBlock = React.createClass({
   render(): any {
     return(
       <div>
-        <p>{ this.state.block.content }</p>
+        <Medium mode={ AppConstants.PREVIEW_MODE } initialContent={ this.state.block.content } />
         { this.childBlockListComponent() }
       </div>
     )

--- a/colonel-kurtz/constants/block_constants.js
+++ b/colonel-kurtz/constants/block_constants.js
@@ -6,7 +6,8 @@ var BlockConstants = KeyMirror({
   BLOCK_CREATE    : null,
   BLOCK_CREATED   : null,
   BLOCK_DESTROY   : null,
-  BLOCK_DESTROYED : null
+  BLOCK_DESTROYED : null,
+  BLOCK_UPDATE    : null
 
 })
 

--- a/colonel-kurtz/mixins/block_type.js
+++ b/colonel-kurtz/mixins/block_type.js
@@ -1,0 +1,43 @@
+/* @flow */
+
+var React        = require('react')
+var AppConstants = require('constants/app_constants')
+var invariant    = require('react/lib/invariant')
+var Pure         = require('mixins/pure')
+
+var BlockType = {
+
+  mixins: [Pure],
+
+  getInitialState() {
+    if (__DEV__) {
+      invariant(this.defaultContent, "BlockType mixin requires `defaultContent` implementation.");
+    }
+
+    return {
+      content: this.props.initialContent || this.defaultContent()
+    }
+  },
+
+  setContent(content) {
+    this.setState({ content: content }, function() {
+      this.props.updateContent(this.state.content)
+    })
+  },
+
+  editMode() {
+    return this.props.mode === AppConstants.EDIT_MODE
+  },
+
+  render() {
+    if (__DEV__) {
+      invariant(this.renderEditor, "BlockType mixin requires `renderEditor` implementation.");
+      invariant(this.renderPreviewer, "BlockType mixin requires `renderPreviewer` implementation.");
+    }
+
+    return this.editMode() ? this.renderEditor() : this.renderPreviewer()
+  }
+
+}
+
+module.exports = BlockType

--- a/colonel-kurtz/models/block.js
+++ b/colonel-kurtz/models/block.js
@@ -6,12 +6,11 @@ var BlockList = require('./block_list')
 class Block {
   id: number;
   parentBlockListId: number;
-  content: string;
 
   constructor(params: {parentBlockListId: number}) {
     this.id = uid()
     this.parentBlockListId = params.parentBlockListId
-    this.content = ""
+    this.content = null
   }
 
   toJSON(): {id: number; content: any; childBlockList: ?BlockList} {
@@ -37,9 +36,14 @@ class Block {
 
     return BlockListStore.findByBlockId(this.id)
   }
+
+  update(newContent: Object) {
+    BlockActions.update({ blockId: this.id, content: newContent })
+  }
 }
 
 module.exports = Block
 
 var BlockListStore = require('../stores/block_list_store')
 var BlockListActions = require('../actions/block_list_actions')
+var BlockActions = require('../actions/block_actions')

--- a/colonel-kurtz/stores/block_store.js
+++ b/colonel-kurtz/stores/block_store.js
@@ -41,6 +41,17 @@ var BlockStore = {
     }
   },
 
+  _update(blockId: number, content: Object) {
+    var block = BlockStore.find(blockId)
+
+    if (block) {
+      // This could probably be done more immutably, but seems fine as is.
+      block.content = content
+
+      Bus.publish()
+    }
+  },
+
   dispatchToken: Dispatcher.register(function(action) {
     switch (action.type) {
       case Constants.BLOCK_CREATE:
@@ -51,7 +62,7 @@ var BlockStore = {
         BlockStore._destroy(action.blockId)
         break
       case Constants.BLOCK_UPDATE:
-        // do a thing
+        BlockStore._update(action.blockId, action.content)
         break
       default:
         // do nothing


### PR DESCRIPTION
Also adds in an action for updating block content.

But the heart of this PR is the first guess at a simple interface for building custom block type components. Component authors just need to include a mixin (I'll think about how we want to expose this for use in components exterior to this core library), and implement 3 methods:
- `defaultContent()`
- `renderEditor()`
- `renderPreviewer()`

Content within the component is all managed via calls to `setComponent` which is analogous to `setState`.

Custom block type registration will be coming soon...

![col-kurtz-block-updates](https://cloud.githubusercontent.com/assets/869491/5211543/1f788602-75a2-11e4-935b-4fe1a88b6432.gif)
