### PR TITLE
Add custom block type registration system

### DIFF
--- a/colonel-kurtz/actions/block_type_actions.js
+++ b/colonel-kurtz/actions/block_type_actions.js
@@ -1,0 +1,17 @@
+/* @flow */
+
+var Constants  = require('constants/block_type_constants')
+var Dispatcher = require('../dispatcher')
+
+var BlockTypeActions = {
+
+  create(params) {
+    Dispatcher.dispatch({
+      type: Constants.BLOCK_TYPE_CREATE,
+      id: params.id,
+      component: params.component
+    })
+  }
+
+}
+module.exports = BlockTypeActions

--- a/colonel-kurtz/components/editor_block.js
+++ b/colonel-kurtz/components/editor_block.js
@@ -3,7 +3,6 @@
 var React = require('react')
 var RemoveBlockButton = require('./remove_block_button')
 var ActLikeBlockWithBlockList = require('../mixins/acts_like_block_with_block_list')
-var Medium = require('./block_types/medium')
 var AppConstants = require('constants/app_constants')
 
 var EditorBlock = React.createClass({
@@ -20,10 +19,11 @@ var EditorBlock = React.createClass({
 
   render(): any {
     var { id, parentBlockListId } = this.state.block
+    var BlockType = this.state.block.component()
 
     return(
       <div className="colonel-block">
-        <Medium mode={ AppConstants.EDIT_MODE } initialContent={ this.state.block.content } updateContent={ this.updateContent } />
+        <BlockType mode={ AppConstants.EDIT_MODE } initialContent={ this.state.block.content } updateContent={ this.updateContent } />
 
         <div className="colonel-toolbar">
           <RemoveBlockButton blockId={ id } blockListId={ parentBlockListId } />

--- a/colonel-kurtz/components/previewer_block.js
+++ b/colonel-kurtz/components/previewer_block.js
@@ -3,7 +3,6 @@
 var React = require('react')
 var ActLikeBlockWithBlockList = require('../mixins/acts_like_block_with_block_list')
 var AppConstants = require('constants/app_constants')
-var Medium = require('./block_types/medium')
 
 var PreviewerBlock = React.createClass({
 
@@ -14,9 +13,11 @@ var PreviewerBlock = React.createClass({
   },
 
   render(): any {
+    var BlockType = this.state.block.component()
+
     return(
       <div>
-        <Medium mode={ AppConstants.PREVIEW_MODE } initialContent={ this.state.block.content } />
+        <BlockType mode={ AppConstants.PREVIEW_MODE } initialContent={ this.state.block.content } />
         { this.childBlockListComponent() }
       </div>
     )

--- a/colonel-kurtz/constants/block_type_constants.js
+++ b/colonel-kurtz/constants/block_type_constants.js
@@ -1,0 +1,9 @@
+/* @flow */
+
+var KeyMirror = require('react/lib/keyMirror')
+
+var BlockTypeConstants = KeyMirror({
+  BLOCK_TYPE_CREATE : null
+})
+
+module.exports = BlockTypeConstants

--- a/colonel-kurtz/index.js
+++ b/colonel-kurtz/index.js
@@ -1,12 +1,16 @@
 /* @flow */
 
-var React = require('react')
-var Immutable = require('immutable')
-var App = require('./components/app')
+var React            = require('react')
+var Immutable        = require('immutable')
+var App              = require('./components/app')
 var BlockListActions = require('./actions/block_list_actions')
-var BlockListStore = require('./stores/block_list_store')
-var exportGlobal = require('./utils/export_global')
-var uid = require('./utils/uid')
+var BlockTypeActions = require('./actions/block_type_actions')
+var BlockListStore   = require('./stores/block_list_store')
+var BlockTypeStore   = require('./stores/block_type_store')
+var BlockTypeMixin   = require('mixins/block_type')
+var exportGlobal     = require('./utils/export_global')
+var uid              = require('./utils/uid')
+var assign           = require('object.assign')
 
 require('array.prototype.find')
 require('style/colonel')
@@ -79,6 +83,22 @@ class ColonelKurtz {
   }
 
 }
+
+ColonelKurtz.addBlockType = function(id, component) {
+  BlockTypeActions.create({ id, component })
+}
+
+ColonelKurtz.createBlock = function(blockClass) {
+  return React.createClass(
+    assign(blockClass, {
+      React: React,
+      mixins: [BlockTypeMixin]
+    })
+  )
+}
+
+// Add core block types
+ColonelKurtz.addBlockType('medium', require('components/block_types/medium'))
 
 module.exports = ColonelKurtz
 

--- a/colonel-kurtz/models/block.js
+++ b/colonel-kurtz/models/block.js
@@ -1,7 +1,8 @@
 /* @flow */
 
-var uid = require('../utils/uid')
-var BlockList = require('./block_list')
+var uid            = require('../utils/uid')
+var BlockList      = require('./block_list')
+var BlockTypeStore = require('stores/block_type_store')
 
 class Block {
   id: number;
@@ -11,10 +12,12 @@ class Block {
     this.id = uid()
     this.parentBlockListId = params.parentBlockListId
     this.content = null
+    // TODO: Demo only. Replace with actual block type determination.
+    this.type = Math.random() > 0.5 ? 'medium' : 'text'
   }
 
   toJSON(): {id: number; content: any; childBlockList: ?BlockList} {
-    var json = { id: this.id, content: this.content }
+    var json = { id: this.id, type: this.type, content: this.content }
 
     var childBlockList = this.childBlockList()
 
@@ -40,10 +43,15 @@ class Block {
   update(newContent: Object) {
     BlockActions.update({ blockId: this.id, content: newContent })
   }
+
+  component() {
+    var blockType = BlockTypeStore.find(this.type)
+    return blockType ? blockType.component : null
+  }
 }
 
 module.exports = Block
 
-var BlockListStore = require('../stores/block_list_store')
+var BlockListStore   = require('../stores/block_list_store')
 var BlockListActions = require('../actions/block_list_actions')
-var BlockActions = require('../actions/block_actions')
+var BlockActions     = require('../actions/block_actions')

--- a/colonel-kurtz/stores/block_type_store.js
+++ b/colonel-kurtz/stores/block_type_store.js
@@ -1,0 +1,37 @@
+/* @flow */
+
+var Constants  = require('../constants/block_type_constants')
+var Dispatcher = require('../dispatcher')
+var Immutable  = require('immutable')
+
+var _blockTypes = Immutable.List()
+
+var BlockTypeStore = {
+
+  all(): Array<Block> {
+    return _blockTypes
+  },
+
+  find(id): Block {
+    return BlockTypeStore.all().find(function(blockType) {
+      return blockType.id === id
+    })
+  },
+
+  _create(id, component) {
+    _blockTypes = _blockTypes.push({ id, component })
+  },
+
+  dispatchToken: Dispatcher.register(function(action) {
+    switch (action.type) {
+      case Constants.BLOCK_TYPE_CREATE:
+        BlockTypeStore._create(action.id, action.component)
+        break
+      default:
+        // do nothing
+    }
+  })
+
+}
+
+module.exports = BlockTypeStore

--- a/example/example.js
+++ b/example/example.js
@@ -1,1 +1,25 @@
+var TextBlock = ColonelKurtz.createBlock({
+  defaultContent: function() {
+    return {
+      text: "I'm a plain text block."
+    };
+  },
+
+  renderEditor: function() {
+    var editor = this.React.createElement('div', { className: 'colonel-block-editor', onBlur: this.onEditorBlur, role: 'textarea', 'aria-multiline': 'true', ref: 'editor', contentEditable: true }, this.state.content.text);
+    return this.React.createElement('div', { className: 'colonel-block-content' }, editor);
+  },
+
+  renderPreviewer: function() {
+    return this.React.createElement('p', null, this.state.content.text);
+  },
+
+  onEditorBlur: function() {
+    var content = { text: this.refs.editor.getDOMNode().innerHTML };
+    this.setContent(content);
+  }
+});
+
+ColonelKurtz.addBlockType('text', TextBlock);
+
 new ColonelKurtz(document.getElementById('app')).render();


### PR DESCRIPTION
Exploring an interface for authoring custom blocks. Check out `example/example.js` for a sample block authored outside of the core library. No external dependencies are required.

![col-kurtz-block-updates-2](https://cloud.githubusercontent.com/assets/869491/5212586/4143fe26-75b9-11e4-9d3a-66d997b198f6.gif)
