### PR TITLE
[add] Colonel can accept an input for blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.9.0
+
+### Noticeable Changes
+
+- Colonel's `blocks` option can accept an input or textarea
+
 ## 2.8.0
 
 As of this release, we will break out changes into those noticeable to

--- a/src/plugins/__tests__/bootstrap.test.js
+++ b/src/plugins/__tests__/bootstrap.test.js
@@ -3,7 +3,7 @@ let bootstrap = require('../bootstrap')
 
 describe('bootstrap plugin', function() {
 
-  it ('can serialize an input', function() {
+  it ('can serialize an input', function(done) {
     let app   = new Colonel({ el: document.createElement('div') })
     let input = document.createElement('textarea')
 
@@ -15,6 +15,7 @@ describe('bootstrap plugin', function() {
 
     bootstrap.register(app, { blocks: input, blockTypes: [] }, function() {
       app.refine('blocks').first().should.have.property('type', 'section')
+      done()
     })
 
   })

--- a/src/plugins/__tests__/bootstrap.test.js
+++ b/src/plugins/__tests__/bootstrap.test.js
@@ -1,0 +1,22 @@
+let Colonel   = require('../../Colonel')
+let bootstrap = require('../bootstrap')
+
+describe('bootstrap plugin', function() {
+
+  it ('can serialize an input', function() {
+    let app   = new Colonel({ el: document.createElement('div') })
+    let input = document.createElement('textarea')
+
+    input.value = JSON.stringify([{
+      blocks  : [],
+      content : {},
+      type    : 'section'
+    }])
+
+    bootstrap.register(app, { blocks: input, blockTypes: [] }, function() {
+      app.refine('blocks').first().should.have.property('type', 'section')
+    })
+
+  })
+
+})

--- a/src/plugins/bootstrap.js
+++ b/src/plugins/bootstrap.js
@@ -3,10 +3,25 @@
  * This plugin is responsible for injecting data into the system
  */
 
+let parseElement = function (element) {
+  let data = []
+
+  try {
+    data = JSON.parse(element.value)
+  } catch(x) {}
+
+  return data
+}
+
 export default {
 
   register(app, { blocks, blockTypes }, next) {
+    if (blocks instanceof HTMLElement) {
+      blocks = parseElement(blocks)
+    }
+
     app.replace({ blocks, blockTypes })
+
     next()
   }
 


### PR DESCRIPTION
Colonel can now support the following behavior:

```javascript
let editor = new ColonelKurtz({
  el     : document.querySelector("#el"),
  blocks : document.querySelector("textarea")
})
