### PR TITLE
[update] Begin menu api

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "webpack -wd --config webpack.example.config.js",
     "prepublish": "NODE_ENV=production webpack -p",
-    "test": "karma start",
+    "test": "NODE_ENV=test karma start",
     "test:once": "CONTINUOUS_INTEGRATION=true npm test",
     "coveralls": "npm run test:once && coveralls < coverage/report-lcov/lcov.info",
     "sass": "node-sass ./example/example.scss --stdout | autoprefixer > ./example/example.css",

--- a/src/__tests__/Colonel.test.js
+++ b/src/__tests__/Colonel.test.js
@@ -66,15 +66,14 @@ describe('ColonelKurtz', function() {
 
   })
 
-  describe('when a shift action is sent to the app', function() {
+  describe('when a move action is sent to the app', function() {
 
     it ('should prepend a new block', function() {
       app.push(Actions.create, 'section')
 
       let block = app.refine('blocks').first()
-      let next  = app.refine('blocks').last()
 
-      app.push(Actions.move, block, next)
+      app.push(Actions.move, block, 1)
 
       app.refine('blocks').last().should.equal(block)
     })

--- a/src/actions/blocks.js
+++ b/src/actions/blocks.js
@@ -13,7 +13,7 @@ export default tag({
     return { id, content }
   },
 
-  move(from, to) {
-    return { from, to }
+  move(block, distance) {
+    return { block, distance }
   }
 })

--- a/src/components/Block.jsx
+++ b/src/components/Block.jsx
@@ -1,12 +1,41 @@
 import Menu from 'components/Menu'
 import React from 'react'
-import { update } from 'actions/blocks'
+import { destroy, move, update } from 'actions/blocks'
 
 export default React.createClass({
 
   propTypes: {
     app   : React.PropTypes.object.isRequired,
     block : React.PropTypes.object.isRequired
+  },
+
+  getActions() {
+    let { app, block, first, last } = this.props
+
+    let actions = [
+      {
+        id       : 'moveUp',
+        label    : 'Move Up',
+        onClick  : app.prepare(move, block, -1),
+        disabled : first
+      },
+      {
+        id       : 'moveDown',
+        label    : 'Move Down',
+        onClick  : app.prepare(move, block, 1),
+        disabled : last
+      },
+      {
+        id      : 'destroy',
+        label   : 'Remove',
+        onClick : app.prepare(destroy, block.id)
+      }
+    ]
+
+    return actions.map(function(action) {
+      let { id } = action
+      return <Menu.Item { ...action } key={ id} ref={ id } />
+    })
   },
 
   render() {
@@ -18,7 +47,10 @@ export default React.createClass({
         <Component ref="block" onChange={ app.prepare(update, block) } { ...block }>
           { children }
         </Component>
-        <Menu app={ app } block={ block } />
+
+        <Menu ref="menu" app={ app } block={ block }>
+          { this.getActions() }
+        </Menu>
       </div>
     )
   }

--- a/src/components/EditorBlock.jsx
+++ b/src/components/EditorBlock.jsx
@@ -10,18 +10,22 @@ let EditorBlock = React.createClass({
     block : React.PropTypes.object.isRequired
   },
 
-  getBlock(block, i) {
-    return (<EditorBlock key={ block } app={ this.props.app } block={ block } />)
+  getBlock(block, i, list) {
+    return (<EditorBlock key={ block }
+                         app={ this.props.app }
+                         block={ block }
+                         first={ i === 0 }
+                         last={ i === list.length - 1 } />)
   },
 
   render() {
-    let { app, block } = this.props
+    let { app, block, last, first } = this.props
 
     let children = app.refine('blocks').filter(i => i.parent === block)
 
     return (
       <div className="col-editor-block">
-        <Block app={ app } block={ block }>
+        <Block app={ app } block={ block } first={ first } last={ last }>
           <Switch app={ app } parent={ block } />
           <Animator>{ children.map(this.getBlock) }</Animator>
         </Block>

--- a/src/components/Menu.jsx
+++ b/src/components/Menu.jsx
@@ -2,36 +2,21 @@ import FocusTrap from 'react-focus-trap'
 import Handle    from './MenuHandle'
 import Item      from './MenuItem'
 import React     from 'react'
-import siblingAt from 'utils/siblingAt'
-
-import { destroy, move } from 'actions/blocks'
 
 export default React.createClass({
 
-  propTypes: {
-    app   : React.PropTypes.object.isRequired,
-    block : React.PropTypes.object.isRequired
-  },
+  statics: { Item },
 
   getInitialState() {
     return { open : false }
   },
 
   render() {
-    let { app, block } = this.props
-    let blocks         = app.get('blocks')
-    let before         = siblingAt(blocks, block, -1)
-    let after          = siblingAt(blocks, block, 1)
-    let moveBlock      = app.prepare(move, block)
-    let destroyBlock   = app.prepare(destroy, block.id)
-
     return (
       <div className="col-menu-wrapper">
         <Handle ref="handle" onClick={ this._onHandleClick }/>
         <FocusTrap element="nav" role="navigation" className="col-menu" onExit={ this._onExit } active={ this.state.open }>
-          <Item ref="moveUp" label="Move Up" onClick={ () => moveBlock(before)} disabled={ !before } />
-          <Item ref="moveDown" label="Move Down" onClick={ () => moveBlock(after) } disabled={ !after } />
-          <Item ref="destroy" label="Remove" onClick={ destroyBlock} />
+          { this.props.children }
         </FocusTrap>
       </div>
     )

--- a/src/components/__tests__/Block.test.jsx
+++ b/src/components/__tests__/Block.test.jsx
@@ -16,7 +16,12 @@ describe('Components - Block', function() {
       }]
     })
 
-    app.start(app.prepare(Actions.create, 'section'), done)
+    app.start(function() {
+      app.push(Actions.create, 'section')
+      app.push(Actions.create, 'section')
+    }, function() {
+      app.push = sinon.mock()
+    }, done)
   })
 
   it ('adds a class name according to the block id', function() {
@@ -32,10 +37,69 @@ describe('Components - Block', function() {
   it ('triggers update when its child component changes', function() {
     let block   = app.refine('blocks').first()
     let subject = TestUtils.renderIntoDocument(<Block app={ app } block={ block } />)
+    let params  = { fiz: 'buzz' }
 
-    subject.refs.block.props.onChange({ fiz: 'buzz' })
+    subject.refs.block.props.onChange(params)
 
-    block.content.should.have.property('fiz', 'buzz')
+    app.push.should.have.been.calledWith(Actions.update, block, params)
+  })
+
+  describe('When the "Remove" button is clicked', function() {
+
+    it ('calls the destroy action', function() {
+      let block = app.refine('blocks').first()
+      let test  = TestUtils.renderIntoDocument(<Block app={ app } block={ block } />)
+
+      test.refs.menu.setState({ open: true })
+
+      TestUtils.Simulate.click(test.refs.destroy.getDOMNode())
+
+      app.push.should.have.been.calledWith(Actions.destroy, block.id)
+    })
+  })
+
+  describe('When the "Move Up" button is clicked', function() {
+    it ('calls the move action', function() {
+      let block = app.refine('blocks').last()
+      let test  = TestUtils.renderIntoDocument(<Block app={ app } block={ block } />)
+
+      test.refs.menu.setState({ open: true })
+
+      TestUtils.Simulate.click(test.refs.moveUp.getDOMNode())
+
+      app.push.should.have.been.calledWith(Actions.move, block, -1)
+    })
+
+     it ('is disabled if it is the first block', function() {
+      let block = app.refine('blocks').first()
+      let test = TestUtils.renderIntoDocument(<Block app={ app } block={ block } first />)
+
+      test.refs.menu.setState({ open: true })
+
+      test.refs.moveUp.props.disabled.should.eql(true)
+    })
+  })
+
+  describe('When the "Move Down" button is clicked', function() {
+    it ('calls the move action', function() {
+      let block = app.refine('blocks').first()
+      let test = TestUtils.renderIntoDocument(<Block app={ app } block={ block } />)
+
+      test.refs.menu.setState({ open: true })
+
+      TestUtils.Simulate.click(test.refs.moveDown.getDOMNode())
+
+      app.push.should.have.been.calledWith(Actions.move, block, 1)
+    })
+
+    it ('is disabled if it is the last block', function() {
+      let block = app.refine('blocks').last()
+      let test = TestUtils.renderIntoDocument(<Block app={ app } block={ block } last />)
+
+      test.refs.menu.setState({ open: true })
+
+      test.refs.moveDown.props.disabled.should.eql(true)
+    })
   })
 
 })

--- a/src/components/__tests__/Menu.test.jsx
+++ b/src/components/__tests__/Menu.test.jsx
@@ -31,71 +31,12 @@ describe('Components - Menu', function() {
     test.state.open.should.equal(false)
   })
 
-  describe('When the "Remove" button is clicked', function() {
-    it ('calls the destroy action', function() {
-      let block = app.refine('blocks').first()
-      let test = TestUtils.renderIntoDocument(<Menu app={ app } block={ block } />)
+  it ('sets the state to open when the menu button is clicked', function() {
+    let block = app.refine('blocks').first()
+    let test = TestUtils.renderIntoDocument(<Menu app={ app } block={ block } />)
 
-      test.setState({ open: true })
+    TestUtils.Simulate.click(test.refs.handle.getDOMNode())
 
-      TestUtils.Simulate.click(test.refs.destroy.getDOMNode())
-
-      app.push.should.have.been.calledWith(destroy, block.id)
-    })
+    test.state.should.have.property('open', true)
   })
-
-  describe('When the "Move Up" button is clicked', function() {
-    it ('calls the move action', function() {
-      let block = app.refine('blocks').last()
-      let test = TestUtils.renderIntoDocument(<Menu app={ app } block={ block } />)
-
-      test.setState({ open: true })
-
-      TestUtils.Simulate.click(test.refs.moveUp.getDOMNode())
-
-      app.push.should.have.been.calledWith(move, block, app.refine('blocks').first())
-    })
-
-     it ('is disabled if it is the first block', function() {
-      let block = app.refine('blocks').first()
-      let test = TestUtils.renderIntoDocument(<Menu app={ app } block={ block } />)
-
-      test.setState({ open: true })
-
-      test.refs.moveUp.props.disabled.should.eql(true)
-    })
-  })
-
-  describe('When the "Move Down" button is clicked', function() {
-    it ('calls the move action', function() {
-      let block = app.refine('blocks').first()
-      let test = TestUtils.renderIntoDocument(<Menu app={ app } block={ block } />)
-      test.setState({ open: true })
-
-      TestUtils.Simulate.click(test.refs.moveDown.getDOMNode())
-
-      app.push.should.have.been.calledWith(move, block, app.refine('blocks').last())
-    })
-
-    it ('is disabled if it is the last block', function() {
-      let block = app.refine('blocks').last()
-      let test = TestUtils.renderIntoDocument(<Menu app={ app } block={ block } />)
-
-      test.setState({ open: true })
-
-      test.refs.moveDown.props.disabled.should.eql(true)
-    })
-  })
-
-  describe('When the "Menu" button is clicked', function() {
-    it ('sets the state to open', function() {
-      let block = app.refine('blocks').first()
-      let test = TestUtils.renderIntoDocument(<Menu app={ app } block={ block } />)
-
-      TestUtils.Simulate.click(test.refs.handle.getDOMNode())
-
-      test.state.should.have.property('open', true)
-    })
-  })
-
 })

--- a/src/stores/Blocks.js
+++ b/src/stores/Blocks.js
@@ -13,7 +13,7 @@ import assign     from 'utils/assign'
 import deepRemove from 'utils/deepRemove'
 import findBy     from 'utils/findBy'
 import insertAt   from 'utils/insertAt'
-import siblingsOf from 'utils/siblingsOf'
+import siblingAt  from 'utils/siblingAt'
 
 export default {
 
@@ -83,9 +83,11 @@ export default {
    * Actions.move
    * Adjust the position of a given block.
    */
-  [Actions.move](state, { from, to }) {
-    let without = state.filter(i => i !== from)
-    return insertAt(without, from, state.indexOf(to))
+  [Actions.move](state, { block, distance }) {
+    let without = state.filter(i => i !== block)
+    let before  = siblingAt(state, block, distance)
+
+    return insertAt(without, block, state.indexOf(before))
   }
 
 }

--- a/src/stores/__tests__/Blocks.test.js
+++ b/src/stores/__tests__/Blocks.test.js
@@ -44,7 +44,7 @@ describe('Stores - Block', function() {
     let target  = new Block({})
     let next    = new Block({})
     let initial = [ new Block({}), target, next ]
-    let state   = Blocks[Actions.move](initial, { from: target, to: next })
+    let state   = Blocks[Actions.move](initial, { block: target, distance: 1 })
 
     state[2].should.equal(target)
   })


### PR DESCRIPTION
Eventually, we will have a Menu API that will allow block types to add new menu items. This lays the groundwork for that, it:

1. Decouples `<Menu />` from menu actions
2. Refactors movement of blocks
3. Begins to abstract away actions into a JS format.