### PR TITLE
[add] Communicate menu clicks to components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2.12.0 (Not published)
+
+### Noticeable Changes
+
+- The API for adding items to menus is now exposed.
+
+TODO: Document menu api
+
 ## 2.11.0
 
 ### Noticeable Changes

--- a/addons/dialog/index.jsx
+++ b/addons/dialog/index.jsx
@@ -1,0 +1,17 @@
+import FocusTrap from 'react-focus-trap'
+import React     from 'react'
+
+export default React.createClass({
+
+  getDefaultProps() {
+    return {
+      className: 'col-dialog'
+    }
+  },
+
+  render() {
+    let { active, children, className, onExit } = this.props
+    return React.createElement(FocusTrap, { active, className, onExit }, children)
+  }
+
+})

--- a/example/blockTypes/Section.jsx
+++ b/example/blockTypes/Section.jsx
@@ -11,6 +11,14 @@ export default React.createClass({
     }]
   },
 
+  getDefaultProps() {
+    return {
+      content: {
+        color: "#eeeeee"
+      }
+    }
+  },
+
   getInitialState() {
     return {
       openSettings: true
@@ -29,13 +37,21 @@ export default React.createClass({
     let { openSettings } = this.state
 
     return (
-      <div>
+      <div style={{ background: this.props.content.color }}>
         <Section { ...this.props } />
         <Dialog active={ openSettings } onExit={ this._onSettingsExit }>
-          <h3 className="col-dialog-title">Hey!</h3>
+          <h3 className="col-dialog-title">Settings!</h3>
+          <label>
+            Color:
+            <input type="color" onChange={ this._onColorChange } value={ this.state.color } />
+          </label>
         </Dialog>
       </div>
     )
+  },
+
+  _onColorChange(e) {
+    this.props.onChange({ color: e.target.value })
   },
 
   _onSettingsExit() {

--- a/example/blockTypes/Section.jsx
+++ b/example/blockTypes/Section.jsx
@@ -1,0 +1,21 @@
+import React from 'react'
+import Section from '../../addons/section'
+
+export default React.createClass({
+
+  statics: {
+    menu: [{
+      id    : 'settings',
+      label : 'Settings'
+    }]
+  },
+
+  menuWillSelect(item) {
+    alert(`The ${ item } item was clicked!`)
+  },
+
+  render() {
+    return (<Section { ...this.props } />)
+  }
+
+})

--- a/example/blockTypes/Section.jsx
+++ b/example/blockTypes/Section.jsx
@@ -1,4 +1,5 @@
-import React from 'react'
+import Dialog  from '../../addons/dialog'
+import React   from 'react'
 import Section from '../../addons/section'
 
 export default React.createClass({
@@ -10,12 +11,35 @@ export default React.createClass({
     }]
   },
 
+  getInitialState() {
+    return {
+      openSettings: true
+    }
+  },
+
   menuWillSelect(item) {
-    alert(`The ${ item } item was clicked!`)
+    switch (item) {
+      case 'settings':
+        this.setState({ openSettings: true })
+        break
+    }
   },
 
   render() {
-    return (<Section { ...this.props } />)
+    let { openSettings } = this.state
+
+    return (
+      <div>
+        <Section { ...this.props } />
+        <Dialog active={ openSettings } onExit={ this._onSettingsExit }>
+          <h3 className="col-dialog-title">Hey!</h3>
+        </Dialog>
+      </div>
+    )
+  },
+
+  _onSettingsExit() {
+    this.setState({ openSettings: false })
   }
 
 })

--- a/example/example.js
+++ b/example/example.js
@@ -8,7 +8,7 @@ let blockTypes = [
   {
     id        : 'section',
     label     : 'Section',
-    component : require('../addons/section'),
+    component : require('./blockTypes/Section'),
     types     : [ 'medium', 'image', 'youtube' ]
   },
   {

--- a/example/style.scss
+++ b/example/style.scss
@@ -1,5 +1,0 @@
-/**
- * Example stylesheet
- */
-
-@import

--- a/package.json
+++ b/package.json
@@ -66,6 +66,6 @@
   "dependencies": {
     "classnames": "^1.x.x",
     "microcosm": "^7.0.x",
-    "react-focus-trap": "^0.5.x"
+    "react-focus-trap": "^0.6.x"
   }
 }

--- a/src/Colonel.jsx
+++ b/src/Colonel.jsx
@@ -21,7 +21,7 @@ import render     from 'plugins/render'
  */
 export default class ColonelKurtz extends Microcosm {
 
-  constructor({ el, blocks, blockTypes }) {
+  constructor(options) {
     super()
 
     /**
@@ -39,12 +39,12 @@ export default class ColonelKurtz extends Microcosm {
      * The bootstrap plugin takes seed data and prepares the
      * application's state beyond initializing
      */
-    this.addPlugin(bootstrap, { blocks, blockTypes })
+    this.addPlugin(bootstrap, options)
 
     /**
      * The render plugin handles updating the browser ui
      */
-    this.addPlugin(render, { el })
+    this.addPlugin(render, options)
   }
 
   toJSON() {

--- a/src/components/Block.jsx
+++ b/src/components/Block.jsx
@@ -9,6 +9,12 @@ export default React.createClass({
     block : React.PropTypes.object.isRequired
   },
 
+  getInitialState() {
+    return {
+      menuOpen: false
+    }
+  },
+
   getBlockType() {
     let { app, block } = this.props
     return app.refine('blockTypes').find(i => i.id === block.type)
@@ -24,9 +30,23 @@ export default React.createClass({
           { children }
         </Component>
 
-        <Menu ref="menu" { ...this.props } items={ Component.menu } onSelect={ this._onSelect } />
+        <Menu ref="menu"
+              { ...this.props }
+              items={ Component.menu }
+              onSelect={ this._onSelect }
+              active={ this.state.menuOpen }
+              onOpen={ this._onMenuOpen }
+              onExit={ this._onMenuExit } />
       </div>
     )
+  },
+
+  _onMenuOpen() {
+    this.setState({ menuOpen: true })
+  },
+
+  _onMenuExit() {
+    this.setState({ menuOpen: false })
   },
 
   _onChange(content) {
@@ -36,6 +56,8 @@ export default React.createClass({
 
   _onSelect(id) {
     let { block } = this.refs
+
+    this._onMenuExit()
 
     if ('menuWillSelect' in block) {
       block.menuWillSelect(id)

--- a/src/components/Block.jsx
+++ b/src/components/Block.jsx
@@ -1,7 +1,6 @@
 import Actions   from 'actions/blocks'
 import Menu      from 'components/Menu'
 import React     from 'react'
-import menuItems from '../config/menu'
 
 export default React.createClass({
 
@@ -15,24 +14,17 @@ export default React.createClass({
     return app.refine('blockTypes').find(i => i.id === block.type)
   },
 
-  getMenuItem(item) {
-    let { id } = item
-    return (<Menu.Item key={ id } ref={ id } { ...item} { ...this.props} />)
-  },
-
   render() {
-    let { type, content } = this.props.block
+    let { app, block, children } = this.props
     let { component:Component } = this.getBlockType()
 
     return (
-      <div className={ `col-block col-block-${ type }`}>
-        <Component ref="block" content={ content } onChange={ this._onChange } >
-          { this.props.children }
+      <div className={ `col-block col-block-${ block.type }`}>
+        <Component ref="block" { ...block } onChange={ this._onChange } >
+          { children }
         </Component>
 
-        <Menu ref="menu">
-          { menuItems.map(this.getMenuItem) }
-        </Menu>
+        <Menu ref="menu" { ...this.props } items={ Component.menu } onSelect={ this._onSelect } />
       </div>
     )
   },
@@ -40,6 +32,14 @@ export default React.createClass({
   _onChange(content) {
     let { app, block } = this.props
     app.push(Actions.update, block, content)
+  },
+
+  _onSelect(id) {
+    let { block } = this.refs
+
+    if ('menuWillSelect' in block) {
+      block.menuWillSelect(id)
+    }
   }
 
 })

--- a/src/components/Menu.jsx
+++ b/src/components/Menu.jsx
@@ -2,13 +2,39 @@ import FocusTrap from 'react-focus-trap'
 import Handle    from './MenuHandle'
 import Item      from './MenuItem'
 import React     from 'react'
+import menuItems from '../config/menu'
 
 export default React.createClass({
 
   statics: { Item },
 
+  propTypes: {
+    app   : React.PropTypes.object.isRequired,
+    block : React.PropTypes.object.isRequired
+  },
+
+  getDefaultProps() {
+    return {
+      items: []
+    }
+  },
+
   getInitialState() {
     return { open : false }
+  },
+
+  getMenuItem(item) {
+    let { id } = item
+
+    return (<Item key={ id }
+                  ref={ id }
+                  { ...item}
+                  { ...this.props}
+                  onBeforeClick={ this.props.onSelect } />)
+  },
+
+  getMenuItems() {
+    return this.props.items.concat(menuItems).map(this.getMenuItem)
   },
 
   render() {
@@ -16,7 +42,7 @@ export default React.createClass({
       <div className="col-menu-wrapper">
         <Handle ref="handle" onClick={ this._onHandleClick }/>
         <FocusTrap element="nav" role="navigation" className="col-menu" onExit={ this._onExit } active={ this.state.open }>
-          { this.props.children }
+          { this.getMenuItems() }
         </FocusTrap>
       </div>
     )

--- a/src/components/Menu.jsx
+++ b/src/components/Menu.jsx
@@ -9,18 +9,14 @@ export default React.createClass({
   statics: { Item },
 
   propTypes: {
-    app   : React.PropTypes.object.isRequired,
-    block : React.PropTypes.object.isRequired
+    app    : React.PropTypes.object.isRequired,
+    block  : React.PropTypes.object.isRequired
   },
 
   getDefaultProps() {
     return {
-      items: []
+      items : [],
     }
-  },
-
-  getInitialState() {
-    return { open : false }
   },
 
   getMenuItem(item) {
@@ -37,24 +33,23 @@ export default React.createClass({
     return this.props.items.concat(menuItems).map(this.getMenuItem)
   },
 
+  getMenu() {
+    return React.createElement(FocusTrap, {
+      active    : this.props.active,
+      className : 'col-menu',
+      element   : 'nav',
+      onExit    : this.props.onExit,
+      role      : 'navigation'
+    }, this.getMenuItems())
+  },
+
   render() {
     return (
       <div className="col-menu-wrapper">
-        <Handle ref="handle" onClick={ this._onHandleClick }/>
-        <FocusTrap element="nav" role="navigation" className="col-menu" onExit={ this._onExit } active={ this.state.open }>
-          { this.getMenuItems() }
-        </FocusTrap>
+        <Handle ref="handle" onClick={ this.props.onOpen }/>
+        { this.getMenu() }
       </div>
     )
-  },
-
-  _onExit() {
-    this.setState({ open: false })
-  },
-
-  _onHandleClick(e) {
-    e.preventDefault()
-    this.setState({ open : !this.state.open })
   }
 
 })

--- a/src/components/MenuItem.jsx
+++ b/src/components/MenuItem.jsx
@@ -6,7 +6,8 @@ export default React.createClass({
   propTypes: {
     app   : React.PropTypes.object.isRequired,
     block : React.PropTypes.object.isRequired,
-    label : React.PropTypes.string.isRequired
+    label : React.PropTypes.string.isRequired,
+    id    : React.PropTypes.string.isRequired
   },
 
   getDefaultProps() {
@@ -14,6 +15,7 @@ export default React.createClass({
       className : 'col-menu-item',
       type      : 'button',
       onClick() {},
+      onBeforeClick() {},
       isDisabled() {}
     }
   },
@@ -34,8 +36,13 @@ export default React.createClass({
   },
 
   _onClick() {
-    let { app, block, onClick } = this.props
-    onClick(app, block)
+    let { app, block, id, onClick, onBeforeClick } = this.props
+
+    // Give the developer a chance to "catch" menu items
+    // before they are processed
+    if (onBeforeClick(id) !== false) {
+      onClick(app, block)
+    }
   }
 
 })

--- a/src/components/__tests__/Menu.test.jsx
+++ b/src/components/__tests__/Menu.test.jsx
@@ -1,3 +1,4 @@
+import Actions from 'actions/blocks'
 import Colonel from '../../Colonel'
 import Menu from '../Menu'
 import Fixture from './fixtures/testBlockType'
@@ -39,4 +40,89 @@ describe('Components - Menu', function() {
 
     test.state.should.have.property('open', true)
   })
+
+  it ('can add new items', function() {
+    let block = app.refine('blocks').first()
+    let items = [{ id: 'test', label: 'Test'}]
+    let test  = TestUtils.renderIntoDocument(<Menu app={ app } block={ block } items={ items } />)
+
+    test.setState({ open: true })
+
+    test.refs.should.have.property('test')
+  })
+
+  describe('When an item is pressed', function() {
+
+    it ('does not activate the action if the onSelect handler returns false', function() {
+      let block = app.refine('blocks').first()
+      let test  = TestUtils.renderIntoDocument(
+        <Menu app={ app } block={ block } onSelect={ (e => false)}/>
+      )
+
+      test.setState({ open: true })
+
+      TestUtils.Simulate.click(test.refs.destroy.getDOMNode())
+
+      app.push.should.not.have.been.called
+    })
+  })
+
+  describe('When the "Remove" button is clicked', function() {
+
+    it ('calls the destroy action', function() {
+      let block = app.refine('blocks').first()
+      let test  = TestUtils.renderIntoDocument(<Menu app={ app } block={ block } />)
+
+      test.setState({ open: true })
+
+      TestUtils.Simulate.click(test.refs.destroy.getDOMNode())
+
+      app.push.should.have.been.calledWith(Actions.destroy, block.id)
+    })
+  })
+
+  describe('When the "Move Up" button is clicked', function() {
+    it ('calls the move action', function() {
+      let block = app.refine('blocks').last()
+      let test  = TestUtils.renderIntoDocument(<Menu app={ app } block={ block } />)
+
+      test.setState({ open: true })
+
+      TestUtils.Simulate.click(test.refs.moveUp.getDOMNode())
+
+      app.push.should.have.been.calledWith(Actions.move, block, -1)
+    })
+
+    it ('is disabled if it is the first block', function() {
+      let block = app.refine('blocks').first()
+      let test = TestUtils.renderIntoDocument(<Menu app={ app } block={ block } />)
+
+      test.setState({ open: true })
+
+      test.refs.moveUp.isDisabled().should.equal(true)
+    })
+  })
+
+  describe('When the "Move Down" button is clicked', function() {
+    it ('calls the move action', function() {
+      let block = app.refine('blocks').first()
+      let test = TestUtils.renderIntoDocument(<Menu app={ app } block={ block } />)
+
+      test.setState({ open: true })
+
+      TestUtils.Simulate.click(test.refs.moveDown.getDOMNode())
+
+      app.push.should.have.been.calledWith(Actions.move, block, 1)
+    })
+
+    it ('is disabled if it is the last block', function() {
+      let block = app.refine('blocks').last()
+      let test = TestUtils.renderIntoDocument(<Menu app={ app } block={ block } />)
+
+      test.setState({ open: true })
+
+      test.refs.moveDown.isDisabled().should.equal(true)
+    })
+  })
+
 })

--- a/style/colonel.scss
+++ b/style/colonel.scss
@@ -19,11 +19,11 @@
   text-align: center;
 
   @import 'reset';
-  @import 'components/switch';
-  @import 'components/menu';
   @import 'components/block';
-  @import 'components/fab';
+  @import 'components/dialog';
   @import 'components/editor';
-  @import 'components/focustrap';
+  @import 'components/fab';
+  @import 'components/menu';
+  @import 'components/switch';
   @import 'utilities';
 }

--- a/style/components/dialog.scss
+++ b/style/components/dialog.scss
@@ -1,0 +1,46 @@
+/**
+ * Dialog
+ * http://www.google.com/design/spec/components/dialogs.html#dialogs-specs
+ */
+
+.col-dialog-wrapper {
+  animation: 0.4s colonel-fade;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  justify-content: center;
+  left: 0;
+  position: fixed;
+  top: 0;
+  width: 100%;
+  z-index: 1000;
+}
+
+.col-dialog-backdrop {
+  background: rgba(0, 0, 0, 0.54);
+  height: 100%;
+  left: 0;
+  position: absolute;
+  top: 0;
+  width: 100%;
+  z-index: 0;
+}
+
+.col-dialog {
+  background: #fff;
+  border-radius: 2px;
+  box-shadow: 0 1px 3px rgba(#000, 0.24);
+  margin: 0 auto;
+  max-height: 100%;
+  max-width: 768px;
+  padding: 24px;
+  position: relative;
+  text-align: left;
+  width: 100%;
+  z-index: 1;
+}
+
+.col-dialog-title {
+  font-size: 24px;
+  margin: 0;
+}

--- a/style/components/dialog.scss
+++ b/style/components/dialog.scss
@@ -41,6 +41,8 @@
 }
 
 .col-dialog-title {
-  font-size: 24px;
-  margin: 0;
+  font-size: 20px;
+  font-weight: 500;
+  margin: 0 0 20px;
+  line-height: 20px;
 }

--- a/style/components/focustrap.scss
+++ b/style/components/focustrap.scss
@@ -1,8 +1,0 @@
-.focus-trap-backdrop {
-  height: 100%;
-  left: 0;
-  position: fixed;
-  top: 0;
-  width: 100%;
-  z-index: 2;
-}

--- a/style/components/menu.scss
+++ b/style/components/menu.scss
@@ -20,8 +20,16 @@ $col-menu-z-index        : 1 !default;
 .col-menu-wrapper {
   position: absolute;
   right: 0;
-  text-align: right;
   top: 0;
+}
+
+.col-menu-backdrop {
+  height: 100%;
+  left: 0;
+  position: fixed;
+  top: 0;
+  width: 100%;
+  z-index: 2;
 }
 
 .col-menu-handle {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,7 +6,8 @@ module.exports = {
     'addons/medium'  : './addons/medium/index.jsx',
     'addons/image'   : './addons/image/index.jsx',
     'addons/youtube' : './addons/youtube/index.jsx',
-    'addons/section' : './addons/section/index.jsx'
+    'addons/section' : './addons/section/index.jsx',
+    'addons/dialog'  : './addons/section/dialog.jsx'
   },
 
   output: {


### PR DESCRIPTION
This pull request defines the basic interface I need for communicating menu item clicks to the associated block component in the UI. It is modelled after the way menus work on Android, but with tweaks to make it feel similarly to the traditional Flux `Dispatcher.register()` behavior.

Whenever a menu item is clicked, it will run a callback upon the associated block:

```javascript
export default React.createClass({

  statics: {
    menu: [{
      id    : 'settings',
      label : 'Settings'
    }]
  },

  menuWillSelect(item) {
    switch(item) {
      case 'settings':
        this.setState({ settingsOpen: true })
        break
    }
  },

  render() {
    return (<div>{ this.props.children }</div>)
  }

})
```

*If `false` is returned from `menuWillSelect`, the action will be igonred*. This gives us another new feature: _the ability to cancel menu item selections within the block type component definition_.

Next steps will expose a way to add new items to the menu from the component definition, however this had to happen first.