### PR TITLE
[update] Rethink api for menu items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+# 2.13.0
+
+### Breaking changes
+
+- Custom menu items are no longer defined in `statics`. Instead, they
+  are returned from a `getMenuItems` method on the component itself.
+- The component lifecycle method `menuWillSelect` has been
+  removed. For the purposes it was required for, `getMenuItems` is sufficient
+
+### Upgrading
+
+- For those using custom menu items, see the updated `menu.md` doc for
+  the updated API.
+
 ## 2.12.2
 
 - `react-ink` was missing in the build. Originally it was compiled

--- a/docs/menus.md
+++ b/docs/menus.md
@@ -1,7 +1,7 @@
 # Menus
 
 1. [Options](#options)
-2. [Walk-through](#walk-through)
+2. [Overview](#overview)
 3. [onClick and isDisabled](#onclick-and-isdisabled)
 
 ## Options
@@ -13,7 +13,7 @@ label      | A user friendly label to show in the menu UI
 onClick    | Optionally, executed when an item is clicked
 isDisabled | A predicate to determine if a menu item should be disabled
 
-## Walk-through
+## Overview
 
 Colonel Kurtz gives each block a menu. By default this menu allows a
 user to change the position of a block or remove it.
@@ -28,19 +28,12 @@ let React = require('react')
 
 module.exports = React.createClass({
 
-  statics: {
-    menu: [{
-      id    : 'hello-world',
-      label : 'Hello World'
+  getMenuItems() {
+    return [{
+      id      : 'hello-world',
+      label   : 'Hello World',
+      onClick : (editor, block) => alert("Hello, world!")
     }]
-  },
-
-  menuWillSelect(item) {
-    switch (item) {
-      case 'hello-world':
-        alert('Hello, world!')
-        break
-    }
   },
 
   render() {
@@ -51,12 +44,8 @@ module.exports = React.createClass({
 
 There are several things going on here:
 
-1. The UI for new menu items is described in the `statics` property of
-   the React component.
-2. Whenever a menu item is clicked, it will execute the
-   `menuWillSelect` function on the component.
-3. `menuWillSelect` is passed the `id` key of the specific menu item
-   that is about to be selected.
+1. The UI for new menu items is described in the `getMenuItems` method
+2. Whenever a menu item is clicked, it will execute the `onClick` option
 
 ## onClick and isDisabled
 
@@ -65,19 +54,12 @@ of these should be functions and are passed the specific editor and
 block for the menu:
 
 ```javascript
-// React Code
-statics: {
-  menu: [{
+getMenuItems() {
+  return [{
     id         : 'hello-world',
     label      : 'Hello World',
     onClick    : (editor, block) => alert(`My block is ${ block.id }`),
     isDisabled : (editor, block) => false
   }]
-},
-// React Code
+}
 ```
-
-At the time of writing, `onClick` and `isDisabled` only know about the
-editor and block they are associated with. Any behavior that requires
-knowledge of the specific component the menu is apart of should be
-handled with `menuWillSelect()`.

--- a/example/blockTypes/Section.jsx
+++ b/example/blockTypes/Section.jsx
@@ -4,13 +4,6 @@ let Section = require('../../addons/section')
 
 module.exports = React.createClass({
 
-  statics: {
-    menu: [{
-      id    : 'settings',
-      label : 'Settings'
-    }]
-  },
-
   getDefaultProps() {
     return {
       content: {
@@ -25,12 +18,12 @@ module.exports = React.createClass({
     }
   },
 
-  menuWillSelect(item) {
-    switch (item) {
-      case 'settings':
-        this.setState({ openSettings: true })
-        break
-    }
+  getMenuItems() {
+    return [{
+      id      : 'settings',
+      label   : 'Settings',
+      onClick : this._onSettingsOpen
+    }]
   },
 
   render() {
@@ -52,6 +45,10 @@ module.exports = React.createClass({
 
   _onColorChange(e) {
     this.props.onChange({ color: e.target.value })
+  },
+
+  _onSettingsOpen() {
+    this.setState({ openSettings: true })
   },
 
   _onSettingsExit() {

--- a/src/components/Block.jsx
+++ b/src/components/Block.jsx
@@ -27,11 +27,6 @@ module.exports = React.createClass({
     }
   },
 
-  setComponentRef(component) {
-    this.setMenuItems(component)
-    return 'block'
-  },
-
   render() {
     let { app, block, children } = this.props
     let { extraMenuItems } = this.state
@@ -39,7 +34,7 @@ module.exports = React.createClass({
 
     return (
       <div className={ `col-block col-block-${ block.type }`}>
-        <Component ref={ this.setComponentRef } { ...block } onChange={ this._onChange } >
+        <Component ref={ this.setMenuItems } { ...block } onChange={ this._onChange } >
           { children }
         </Component>
 

--- a/src/components/Block.jsx
+++ b/src/components/Block.jsx
@@ -11,7 +11,8 @@ module.exports = React.createClass({
 
   getInitialState() {
     return {
-      menuOpen: false
+      extraMenuItems : [],
+      menuOpen       : false
     }
   },
 
@@ -20,20 +21,31 @@ module.exports = React.createClass({
     return app.refine('blockTypes').find(i => i.id === block.type)
   },
 
+  setMenuItems(component) {
+    if ('getMenuItems' in component) {
+      this.setState({ extraMenuItems: component.getMenuItems() })
+    }
+  },
+
+  setComponentRef(component) {
+    this.setMenuItems(component)
+    return 'block'
+  },
+
   render() {
     let { app, block, children } = this.props
+    let { extraMenuItems } = this.state
     let { component:Component } = this.getBlockType()
 
     return (
       <div className={ `col-block col-block-${ block.type }`}>
-        <Component ref="block" { ...block } onChange={ this._onChange } >
+        <Component ref={ this.setComponentRef } { ...block } onChange={ this._onChange } >
           { children }
         </Component>
 
         <Menu ref="menu"
               { ...this.props }
-              items={ Component.menu }
-              onSelect={ this._onSelect }
+              items={ extraMenuItems }
               active={ this.state.menuOpen }
               onOpen={ this._onMenuOpen }
               onExit={ this._onMenuExit } />
@@ -52,16 +64,6 @@ module.exports = React.createClass({
   _onChange(content) {
     let { app, block } = this.props
     app.push(Actions.update, block, content)
-  },
-
-  _onSelect(id) {
-    let { block } = this.refs
-
-    this._onMenuExit()
-
-    if ('menuWillSelect' in block) {
-      block.menuWillSelect(id)
-    }
   }
 
 })

--- a/src/components/Menu.jsx
+++ b/src/components/Menu.jsx
@@ -15,18 +15,13 @@ module.exports = React.createClass({
 
   getDefaultProps() {
     return {
-      items : [],
+      items : []
     }
   },
 
   getMenuItem(item) {
     let { id } = item
-
-    return (<Item key={ id }
-                  ref={ id }
-                  { ...item}
-                  { ...this.props}
-                  onBeforeClick={ this.props.onSelect } />)
+    return (<Item key={ id } ref={ id } { ...item} { ...this.props} />)
   },
 
   getMenuItems() {

--- a/src/components/MenuItem.jsx
+++ b/src/components/MenuItem.jsx
@@ -15,7 +15,6 @@ module.exports = React.createClass({
       className : 'col-menu-item',
       type      : 'button',
       onClick() {},
-      onBeforeClick() {},
       isDisabled() {}
     }
   },
@@ -36,13 +35,8 @@ module.exports = React.createClass({
   },
 
   _onClick() {
-    let { app, block, id, onClick, onBeforeClick } = this.props
-
-    // Give the developer a chance to "catch" menu items
-    // before they are processed
-    if (onBeforeClick(id) !== false) {
-      onClick(app, block)
-    }
+    let { app, block, onClick } = this.props
+    onClick(app, block)
   }
 
 })

--- a/src/components/__tests__/Block.test.jsx
+++ b/src/components/__tests__/Block.test.jsx
@@ -22,13 +22,13 @@ describe('Components - Block', function() {
     component.getDOMNode().className.should.include(block.type)
   })
 
-  it ('sends an onMenuOpen callback to the menu it owns', function() {
+  it ('sends an onOpen callback to the menu it owns', function() {
     component.refs.menu.props.onOpen()
     component.state.should.have.property('menuOpen', true)
   })
 
-  it ('updates a block when its child component changes', function() {
-    component.refs.block.props.onChange({ fiz: 'buzz' })
+  it ('updates a block when it changes', function() {
+    component._onChange({ fiz: 'buzz' })
     component.props.block.content.should.have.property('fiz', 'buzz')
   })
 
@@ -38,31 +38,11 @@ describe('Components - Block', function() {
     menu.refs.should.have.property('test')
   })
 
-  describe('When a menu item is selected', function() {
-
-    it ('calls `menuWillSelect` upon the sibling block component', function() {
-      let { menu, block } = component.refs
-
-      block.menuWillSelect = sinon.mock()
-
-      component.setState({ menuOpen: true })
-
-      TestUtils.Simulate.click(menu.refs.destroy.getDOMNode())
-
-      block.menuWillSelect.should.have.been.called
-    })
-
-    it ('does nothing if `menuWillSelect` has not been defined', function() {
-      let item = app.get(['blocks', 0])
-      let { menu } = component.refs
-
-      component.setState({ menuOpen: true })
-
-      TestUtils.Simulate.click(menu.refs.destroy.getDOMNode())
-
-      app.get(['blocks', 0]).should.not.equal(item)
-    })
-
+  it ('can close a menu', function() {
+    let { menu } = component.refs
+    component.setState({ menuOpen: true })
+    menu.props.onExit()
+    component.state.menuOpen.should.equal(false)
   })
 
 })

--- a/src/components/__tests__/Menu.test.jsx
+++ b/src/components/__tests__/Menu.test.jsx
@@ -35,12 +35,6 @@ describe('Components - Menu', function() {
     test.refs.should.have.property('test')
   })
 
-  it ('does not activate the action if the onSelect handler returns false', function() {
-    let test = render(React.cloneElement(menu, { onSelect: (e => false) }))
-    TestUtils.Simulate.click(test.refs.destroy.getDOMNode())
-    app.push.should.not.have.been.called
-  })
-
   it ('calls the destroy action', function() {
     let test  = render(menu)
     let block = test.props.block

--- a/src/components/__tests__/fixtures/testBlockType.js
+++ b/src/components/__tests__/fixtures/testBlockType.js
@@ -2,8 +2,8 @@ module.exports = {
   id: 'test',
   label: 'Test',
   component: {
-    statics: {
-      menu: [{ id: 'test', label: 'Test' }]
+    getMenuItems() {
+      return [{ id: 'test', label: 'Test' }]
     },
     render() {
       return <div>{ this.props.children }</div>


### PR DESCRIPTION
After conducting integration of the new Menu API on a project, @cwmanning and I chatted about a better way to include menu items. Too much complexity is added around referencing the block type component associated with a menu. 

This PR is an attempt to provide an alternative, potentially better API for menus.

Also @cwmanning is a genius