### PR TITLE
[add] Key input to SwitchNavs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+# 2.15.0 (Not released)
+
+### Noticeable Changes
+
+- The menu to add new blocks will now collapse when the escape key is
+  pressed.
+
 # 2.14.0
 
 New style updates warranted a minor release, however we also

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 - The menu to add new blocks will now collapse when the escape key is
   pressed.
+- Refactored switch navigation to be smarter about secondary
+  buttons. This will require an update to the stylesheet if you are
+  not including it from `node_modules`.
 
 # 2.14.0
 

--- a/src/components/ActionButton.jsx
+++ b/src/components/ActionButton.jsx
@@ -1,18 +1,16 @@
-let Btn        = require('./Button')
-let React      = require('react')
-let classNames = require('classnames')
+let Btn   = require('./Button')
+let React = require('react')
 
 module.exports = React.createClass({
 
   propTypes: {
+    label   : React.PropTypes.string.isRequired,
     onClick : React.PropTypes.func.isRequired
   },
 
   getDefaultProps() {
     return {
       className : 'col-btn-fab',
-      label     : 'Open block creation menu',
-      secondary : false,
       symbol    : '+'
     }
   },

--- a/src/components/Button.jsx
+++ b/src/components/Button.jsx
@@ -6,21 +6,18 @@ module.exports = React.createClass({
   getDefaultProps() {
     return {
       className : 'col-btn',
-      hide      : false,
       tagName   : 'button',
       type      : 'button'
     }
   },
 
   render() {
-    let { children, hide, tagName, ...attrs } = this.props
+    let { children, tagName, ...attrs } = this.props
 
-    return hide ? null : (
-      React.createElement(tagName, attrs, [
-        <Ink key="__ink__"/>,
-        children
-      ])
-    )
+    return React.createElement(tagName, attrs, [
+      <Ink key="__ink__"/>,
+      children
+    ])
   }
 
 })

--- a/src/components/Switch.jsx
+++ b/src/components/Switch.jsx
@@ -1,7 +1,7 @@
+let ActionButton  = require('./ActionButton')
 let Actions       = require('../actions/blocks')
 let React         = require('react')
 let SwitchNav     = require('./SwitchNav')
-let SwitchToggle  = require('./SwitchToggle')
 let classNames    = require('classnames')
 let typesForBlock = require('../utils/typesForBlock')
 
@@ -28,7 +28,9 @@ module.exports = React.createClass({
   getToggle(open) {
     if (open) return null
 
-    return (<SwitchToggle ref="toggle" onClick={ this._onToggle } />)
+    return (<ActionButton ref="toggle"
+                          label="Open the block menu and create a block"
+                          onClick={ this._onToggle } />)
   },
 
   getNav(open, blockTypes) {

--- a/src/components/Switch.jsx
+++ b/src/components/Switch.jsx
@@ -28,22 +28,22 @@ module.exports = React.createClass({
   getToggle(open) {
     if (open) return null
 
-    return (<SwitchToggle ref="toggle"
-                          onClick={ this._onToggle }
-                          secondary={ this.props.parent } />)
+    return (<SwitchToggle ref="toggle" onClick={ this._onToggle } />)
   },
 
   getNav(open, blockTypes) {
     if (!open) return null
 
-    let { app, parent, position } = this.props
-
     return (<SwitchNav ref="nav"
-                       app={ app }
                        blockTypes={ blockTypes }
-                       onExit={ this._onNavExit }
-                       parent={ parent }
-                       position={ position } />)
+                       onAdd={ this._onAdd }
+                       onExit={ this.close } />)
+  },
+
+  close() {
+    this.setState({ open: false }, () => {
+      this.refs.toggle.focus()
+    })
   },
 
   render() {
@@ -60,10 +60,9 @@ module.exports = React.createClass({
     ) : null
   },
 
-  _onNavExit() {
-    this.setState({ open: false }, () => {
-      this.refs.toggle.focus()
-    })
+  _onAdd(id) {
+    let { app, position, parent } = this.props
+    app.push(Actions.create, id, position, parent)
   },
 
   _onToggle() {

--- a/src/components/Switch.jsx
+++ b/src/components/Switch.jsx
@@ -26,17 +26,24 @@ module.exports = React.createClass({
   },
 
   getToggle(open) {
-    let { parent } = this.props
+    if (open) return null
 
-    return !open ? (
-      <SwitchToggle onClick={ this._onToggle } secondary={ parent } />
-    ) : null
+    return (<SwitchToggle ref="toggle"
+                          onClick={ this._onToggle }
+                          secondary={ this.props.parent } />)
   },
 
   getNav(open, blockTypes) {
+    if (!open) return null
+
     let { app, parent, position } = this.props
 
-    return open ? React.createElement(SwitchNav, { app, blockTypes, parent, position }) : null
+    return (<SwitchNav ref="nav"
+                       app={ app }
+                       blockTypes={ blockTypes }
+                       onExit={ this._onNavExit }
+                       parent={ parent }
+                       position={ position } />)
   },
 
   render() {
@@ -51,6 +58,12 @@ module.exports = React.createClass({
         { this.getNav(open, types) }
       </div>
     ) : null
+  },
+
+  _onNavExit() {
+    this.setState({ open: false }, () => {
+      this.refs.toggle.focus()
+    })
   },
 
   _onToggle() {

--- a/src/components/SwitchNav.jsx
+++ b/src/components/SwitchNav.jsx
@@ -1,22 +1,23 @@
-let Actions = require('../actions/blocks')
-let Btn     = require('./Button')
-let React   = require('react')
+let Btn   = require('./Button')
+let React = require('react')
 
 module.exports = React.createClass({
 
   propTypes: {
-    app        : React.PropTypes.object.isRequired,
     blockTypes : React.PropTypes.array.isRequired,
-    onExit     : React.PropTypes.func.isRequired
+    onExit     : React.PropTypes.func.isRequired,
+    onAdd      : React.PropTypes.func.isRequired
   },
 
   componentDidMount() {
     this.getDOMNode().querySelector('button').focus()
   },
 
-  getButton({ id, label }, i) {
+  getButton({ id, label }) {
+    let { onAdd } = this.props
+
     return (
-      <Btn key={ id } className="col-switch-btn" onClick={ () => this._onAdd(id) }>
+      <Btn key={ id } className="col-switch-btn" onClick={ () => onAdd(id) }>
         { label }
       </Btn>
     )
@@ -28,11 +29,6 @@ module.exports = React.createClass({
         { this.props.blockTypes.map(this.getButton)}
       </nav>
     )
-  },
-
-  _onAdd(id) {
-    let { app, position, parent } = this.props
-    app.push(Actions.create, id, position, parent)
   },
 
   _onKeyUp(e) {

--- a/src/components/SwitchNav.jsx
+++ b/src/components/SwitchNav.jsx
@@ -6,7 +6,8 @@ module.exports = React.createClass({
 
   propTypes: {
     app        : React.PropTypes.object.isRequired,
-    blockTypes : React.PropTypes.array.isRequired
+    blockTypes : React.PropTypes.array.isRequired,
+    onExit     : React.PropTypes.func.isRequired
   },
 
   componentDidMount() {
@@ -23,7 +24,7 @@ module.exports = React.createClass({
 
   render() {
     return (
-      <nav className="col-switch-nav" role="navigation">
+      <nav className="col-switch-nav" role="navigation" onKeyUp={ this._onKeyUp }>
         { this.props.blockTypes.map(this.getButton)}
       </nav>
     )
@@ -32,6 +33,12 @@ module.exports = React.createClass({
   _onAdd(id) {
     let { app, position, parent } = this.props
     app.push(Actions.create, id, position, parent)
+  },
+
+  _onKeyUp(e) {
+    if (e.key === 'Escape') {
+      this.props.onExit()
+    }
   }
 
 })

--- a/src/components/SwitchToggle.jsx
+++ b/src/components/SwitchToggle.jsx
@@ -11,21 +11,24 @@ module.exports = React.createClass({
   getDefaultProps() {
     return {
       label     : 'Open block creation menu',
-      hide      : false,
       secondary : false,
       symbol    : '+'
     }
   },
 
+  focus() {
+    this.getDOMNode().focus()
+  },
+
   render() {
-    let { label, hide, onClick, secondary, symbol } = this.props
+    let { label, onClick, secondary, symbol } = this.props
 
     let className = classNames('col-btn-fab', {
       'col-btn-fab-secondary' : secondary
     })
 
     return (
-      <Btn ref="toggle" className={ className } onClick={ onClick } hide={ hide }>
+      <Btn ref="toggle" className={ className } onClick={ onClick }>
         <span className="col-hidden">{ label }</span>
         <span aria-hidden="true">{ symbol }</span>
       </Btn>

--- a/src/components/SwitchToggle.jsx
+++ b/src/components/SwitchToggle.jsx
@@ -10,6 +10,7 @@ module.exports = React.createClass({
 
   getDefaultProps() {
     return {
+      className : 'col-btn-fab',
       label     : 'Open block creation menu',
       secondary : false,
       symbol    : '+'
@@ -21,14 +22,10 @@ module.exports = React.createClass({
   },
 
   render() {
-    let { label, onClick, secondary, symbol } = this.props
-
-    let className = classNames('col-btn-fab', {
-      'col-btn-fab-secondary' : secondary
-    })
+    let { className, label, onClick, secondary, symbol } = this.props
 
     return (
-      <Btn ref="toggle" className={ className } onClick={ onClick }>
+      <Btn className={ className } onClick={ onClick }>
         <span className="col-hidden">{ label }</span>
         <span aria-hidden="true">{ symbol }</span>
       </Btn>

--- a/src/components/__tests__/Switch.test.jsx
+++ b/src/components/__tests__/Switch.test.jsx
@@ -5,6 +5,7 @@ let Switch  = require('../Switch')
 
 describe('Components - Switch', function() {
   let TestUtils = React.addons.TestUtils
+  let render    = TestUtils.renderIntoDocument
   let app;
 
   beforeEach(function(done) {
@@ -17,13 +18,15 @@ describe('Components - Switch', function() {
   })
 
   it ('closes when it gets new properties', function() {
-    let base = TestUtils.renderIntoDocument(<Switch app={ app } open />)
-    base.forceUpdate()
+    let base = render(<Switch app={ app } />)
+
+    base.setState({ open: true })
+    base.componentWillReceiveProps()
     base.state.open.should.equal(false)
   })
 
   it ('adds a block type on click', function() {
-    let base = TestUtils.renderIntoDocument(<Switch app={ app } forceOpen />)
+    let base = render(<Switch app={ app } forceOpen />)
     let spy  = sinon.spy(app, 'push')
 
     TestUtils.Simulate.click(base.getDOMNode().querySelector('.col-switch-btn'))
@@ -34,7 +37,7 @@ describe('Components - Switch', function() {
   describe('When only one block type given', function() {
     it ('_onToggle creates that block type', function() {
       let spy       = sinon.spy(app, 'push')
-      let component = TestUtils.renderIntoDocument(<Switch app={ app } />)
+      let component = render(<Switch app={ app } />)
 
       component._onToggle()
 
@@ -56,7 +59,7 @@ describe('Components - Switch', function() {
     })
 
     it ('_onToggle sets the state to open', function() {
-      let component = TestUtils.renderIntoDocument(<Switch app={ app } />)
+      let component = render(<Switch app={ app } />)
       component._onToggle()
       component.state.open.should.equal(true)
     })
@@ -79,7 +82,7 @@ describe('Components - Switch', function() {
     })
 
     it ('getTypes should display multiple blocks', function() {
-      let component = TestUtils.renderIntoDocument(<Switch app={ app } parent={ app.get('blocks')[0] }/>)
+      let component = render(<Switch app={ app } parent={ app.get('blocks')[0] }/>)
 
       component.setState({ open : true })
       component.getDOMNode().querySelectorAll('button').length.should.be.gt(1)
@@ -98,8 +101,26 @@ describe('Components - Switch', function() {
     })
 
     it ('renders nothing', function() {
-      let component = TestUtils.renderIntoDocument(<Switch app={ app } parent={ app.get('blocks')[0] }/>)
+      let component = render(<Switch app={ app } parent={ app.get('blocks')[0] }/>)
       expect(component.getDOMNode()).to.equal(null)
+    })
+  })
+
+  describe('Key presses', function() {
+    it ('closes when the escape key is presed', function() {
+      let base = render(<Switch app={ app } />)
+
+      base.setState({ open: true })
+      TestUtils.Simulate.keyUp(base.refs.nav.getDOMNode(), { key: 'Escape' })
+      base.state.open.should.equal(false)
+    })
+
+    it ('does not close when another key is presed', function() {
+      let base = render(<Switch app={ app } />)
+
+      base.setState({ open: true })
+      TestUtils.Simulate.keyUp(base.refs.nav.getDOMNode(), { key: 'q' })
+      base.state.open.should.equal(true)
     })
   })
 

--- a/style/components/fab.scss
+++ b/style/components/fab.scss
@@ -64,7 +64,8 @@ $col-fab-background     : $col-primary !default;
   }
 }
 
-.col-btn-fab-secondary {
+// Fabs within blocks should appear smaller
+.col-block .col-btn-fab {
   background: $col-secondary;
   border: none;
   color: rgba(#000, 0.54);


### PR DESCRIPTION
BlockType switch navigation will now collapse when the escape key is pressed. I also removed some dead code.

![keys](https://cloud.githubusercontent.com/assets/590904/7430591/629767da-efe3-11e4-9e91-c7b1c2d2b54b.gif)
