### PR TITLE
[update] Ensure default content object

### DIFF
--- a/src/models/Block.js
+++ b/src/models/Block.js
@@ -4,7 +4,7 @@ class Block {
 
   constructor(params) {
     this.id      = uid()
-    this.content = params.content
+    this.content = params.content || {}
     this.parent  = params.parent
     this.type    = params.type
   }

--- a/src/models/__tests__/Block.test.js
+++ b/src/models/__tests__/Block.test.js
@@ -21,4 +21,22 @@ describe('Models - Block', function() {
     answer.should.equal(block.id)
   })
 
+  describe('when created without a content attribute', function() {
+
+    it ('ensures the attribute is an empty object', function() {
+      let block  = new Block({})
+      block.content.should.eql({})
+    })
+
+  })
+
+  describe('when created with a content property that is falsy', function() {
+    [ false, null, undefined, '' ].forEach(function(type) {
+      it (`ensures the attribute is an empty object on ${ type }`, function() {
+        let block  = new Block({ content: type })
+        block.content.should.eql({})
+      })
+    })
+  })
+
 })

--- a/src/stores/__tests__/Blocks.test.js
+++ b/src/stores/__tests__/Blocks.test.js
@@ -60,4 +60,11 @@ describe('Stores - Block', function() {
     state[1].type.should.equal('expected')
   })
 
+  it ('maintains an empty content object when deserialized', function() {
+    let blocks = [ new Block({}) ]
+    let state   = Blocks.deserialize(blocks)
+
+    state[0].content.should.eql({})
+  })
+
 })


### PR DESCRIPTION
The content attribute should always be an object, even if it is empty.