### PR TITLE
Add allow instantiation option, only allow specific block types to enter CK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Improved focus state of block creator menu buttons.
 - Added `col-block-editor` and `col-block-children` css hooks
 - `Field` component can take an `element` option (for text areas, defaults to `input`)
+- Added `allow` property to configuration options to only allow specific blocks
 
 ## 2.17
 

--- a/src/plugins/__tests__/bootstrap.test.js
+++ b/src/plugins/__tests__/bootstrap.test.js
@@ -17,7 +17,32 @@ describe('bootstrap plugin', function() {
       app.refine('blocks').first().should.have.property('type', 'section')
       done()
     })
-
   })
 
+  it ('filter block types given a list', function(done) {
+    let app = new Colonel({ el : document.createElement('div') })
+
+    bootstrap.register(app, {
+      allow: [ 'list' ],
+      blockTypes : [{ id: 'list' }, { id: 'text' }]
+    }, function() {
+      let types = app.refine('blockTypes')
+
+      types.size().should.equal(1)
+      types.first().id.should.equal('list')
+
+      done()
+    })
+  })
+
+  it ('allows all block types if given no allow option', function(done) {
+    let app = new Colonel({ el : document.createElement('div') })
+
+    bootstrap.register(app, {
+      blockTypes : [{ id: 'list' }, { id: 'text' }]
+    }, function() {
+      app.refine('blockTypes').size().should.equal(2)
+      done()
+    })
+  })
 })

--- a/src/plugins/bootstrap.js
+++ b/src/plugins/bootstrap.js
@@ -15,12 +15,18 @@ let parseElement = function (element) {
 
 module.exports = {
 
-  register(app, { blocks, blockTypes }, next) {
+  filter(blockTypes, acceptable) {
+    if (!acceptable) return blockTypes
+
+    return blockTypes.filter(type => acceptable.indexOf(type.id) > -1)
+  },
+
+  register(app, { allow, blocks, blockTypes }, next) {
     if (blocks instanceof HTMLElement) {
       blocks = parseElement(blocks)
     }
 
-    app.replace({ blocks, blockTypes })
+    app.replace({ blocks, blockTypes: this.filter(blockTypes, allow) })
 
     next()
   }


### PR DESCRIPTION
This PR allows blockTypes to be whitelisted with:

```
new ColonelKurtz({
  blockTypes: [...],
  allow: [ 'text', 'image', 'video' ]
})
```