### PR TITLE
[fix] Always properly associate labels in Field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Added `allow` property to configuration options to only allow specific blocks
 - The Youtube and Image addons strip white space when checking to open
 - Upgraded Microcosm to 8.1.0
+- `Field` component now takes extra precautions to ensure labels are associated with inputs.
 
 ## 2.17.0
 

--- a/addons/common/__tests__/field.test.jsx
+++ b/addons/common/__tests__/field.test.jsx
@@ -30,4 +30,11 @@ describe('Addons - Common - Field', function () {
 
     label.htmlFor.should.equal(input.id)
   })
+
+  it ('properly handles spaces in labels when assigning ids', function() {
+    let component = render(<Field label="Test Field" />)
+    let input = component.getDOMNode().querySelector(".col-field-input")
+
+    input.id.should.equal('test-field')
+  })
 })

--- a/addons/common/__tests__/field.test.jsx
+++ b/addons/common/__tests__/field.test.jsx
@@ -4,14 +4,30 @@ let render    = TestUtils.renderIntoDocument
 
 describe('Addons - Common - Field', function () {
   it ('defaults to input element', function() {
-    let component = render(<Field />)
+    let component = render(<Field label="Test" />)
     let tag = component.getDOMNode().querySelector(".col-field-input").tagName
     tag.should.equal('INPUT')
   })
 
   it ('uses element instead of input if provided', function() {
-    let component = render(<Field element='textarea' />)
+    let component = render(<Field element='textarea' label="Test" />)
     let tag = component.getDOMNode().querySelector(".col-field-input").tagName
     tag.should.equal('TEXTAREA')
+  })
+
+  it ('falls back to the name property when getting an id', function() {
+    let component = render(<Field label="Test" name="test" />)
+    let input = component.getDOMNode().querySelector(".col-field-input")
+    let label = component.getDOMNode().querySelector(".col-field-label")
+
+    label.htmlFor.should.equal(input.id)
+  })
+
+  it ('falls back to the label property when getting an id with no name', function() {
+    let component = render(<Field label="Test" />)
+    let input = component.getDOMNode().querySelector(".col-field-input")
+    let label = component.getDOMNode().querySelector(".col-field-label")
+
+    label.htmlFor.should.equal(input.id)
   })
 })

--- a/addons/common/field.jsx
+++ b/addons/common/field.jsx
@@ -3,9 +3,14 @@
  * A reuseable field element
  */
 
-let React = require('react')
+let React   = require('react')
+let slugify = require('./slugify')
 
 module.exports = React.createClass({
+
+  propTypes: {
+    label: React.PropTypes.string.isRequired
+  },
 
   getDefaultProps() {
     return {
@@ -14,13 +19,21 @@ module.exports = React.createClass({
     }
   },
 
+  getID() {
+    return this.props.id || this.props.name || slugify(this.props.label)
+  },
+
+  getName() {
+    return this.name || this.getID()
+  },
+
   render() {
-    var { label, name, type, element:Element, ...props } = this.props
+    let { label, name, type, element:Element, id, ...props } = this.props
 
     return (
       <div className="col-field">
-        <label className="col-field-label" htmlFor={ name || this.props.id }>{ label }</label>
-        <Element className="col-field-input" type={ type } { ...props } name={ name || this.props.id } />
+        <label className="col-field-label" htmlFor={ this.getID() }>{ label }</label>
+        <Element className="col-field-input" type={ type } { ...props } name={ this.getName() } id={ this.getID() } />
       </div>
     )
   }

--- a/addons/common/slugify.js
+++ b/addons/common/slugify.js
@@ -1,0 +1,8 @@
+module.exports = function slugify(text) {
+  return text.toString().toLowerCase()
+    .replace(/\s+/g, '-')           // Replace spaces with -
+    .replace(/[^\w\-]+/g, '')       // Remove all non-word chars
+    .replace(/\-\-+/g, '-')         // Replace multiple - with single -
+    .replace(/^-+/, '')             // Trim - from start of text
+    .replace(/-+$/, '');            // Trim - from end of text
+}

--- a/style/addons/common.scss
+++ b/style/addons/common.scss
@@ -14,6 +14,7 @@ $col-field-focus-color : #009688 !default;
 
 .col-field-label {
   color: #777;
+  cursor: pointer;
   display: block;
   float: none;
   font-size: 13px;


### PR DESCRIPTION
Fixes #78

The `<Field />` component will always properly link up a label to an input. These formats are supported:

```javascript
<Field label="Title" /> // => id is "title"
<Field label="Title" name="custom_name" /> // => id is "custom_name"
<Field label="Title" id="custom_id" /> // => id is "custom_id"
```