### PR TITLE
[add] Private blocks

### DIFF
--- a/docs/blockTypes.md
+++ b/docs/blockTypes.md
@@ -18,6 +18,8 @@ Property  | Description
 id        | A unique identifier. Assigned to a block when it is created
 label     | A display name given to the block type in the interface
 component | A React component used to edit a block of a given type
+types     | An array of other BlockType ids that may be created as children
+root      | Configures the BlockType to display in the menu unless specifically asked for using `types`. Defaults to true.
 
 ## Creating Block Types
 

--- a/example/example.js
+++ b/example/example.js
@@ -22,7 +22,7 @@ let blockTypes = [
     id        : 'child-text',
     label     : 'Child Text',
     component : require('../addons/medium'),
-    childOnly : true
+    root : true
   },
   {
     id        : 'image',

--- a/example/example.js
+++ b/example/example.js
@@ -11,12 +11,18 @@ let blockTypes = [
     id        : 'section',
     label     : 'Section',
     component : require('./blockTypes/Section'),
-    types     : [ 'medium', 'image', 'youtube' ]
+    types     : [ 'child-text', 'image', 'youtube' ]
   },
   {
     id        : 'medium',
     label     : 'Text',
     component : require('../addons/medium')
+  },
+  {
+    id        : 'child-text',
+    label     : 'Child Text',
+    component : require('../addons/medium'),
+    private   : true
   },
   {
     id        : 'image',

--- a/example/example.js
+++ b/example/example.js
@@ -22,7 +22,7 @@ let blockTypes = [
     id        : 'child-text',
     label     : 'Child Text',
     component : require('../addons/medium'),
-    root : true
+    root      : false
   },
   {
     id        : 'image',

--- a/example/example.js
+++ b/example/example.js
@@ -22,7 +22,7 @@ let blockTypes = [
     id        : 'child-text',
     label     : 'Child Text',
     component : require('../addons/medium'),
-    private   : true
+    childOnly : true
   },
   {
     id        : 'image',

--- a/src/models/BlockType.js
+++ b/src/models/BlockType.js
@@ -2,7 +2,7 @@ let React = require('react')
 
 class BlockType {
 
-  constructor({ component, menuItems, label, types, id }) {
+  constructor({ component, menuItems, label, types, id, private }) {
     if (typeof component === 'object') {
       component = React.createClass(component)
     }
@@ -12,6 +12,7 @@ class BlockType {
     this.types     = types || []
     this.component = component
     this.menuItems = menuItems
+    this.private   = private
   }
 
   valueOf() {

--- a/src/models/BlockType.js
+++ b/src/models/BlockType.js
@@ -2,7 +2,7 @@ let React = require('react')
 
 class BlockType {
 
-  constructor({ component, menuItems, label, types, id, private }) {
+  constructor({ component, menuItems, label, types, id, childOnly }) {
     if (typeof component === 'object') {
       component = React.createClass(component)
     }
@@ -12,7 +12,7 @@ class BlockType {
     this.types     = types || []
     this.component = component
     this.menuItems = menuItems
-    this.private   = private
+    this.childOnly = childOnly
   }
 
   valueOf() {

--- a/src/models/BlockType.js
+++ b/src/models/BlockType.js
@@ -1,8 +1,12 @@
 let React = require('react')
 
+let defaults = { root: true }
+
 class BlockType {
 
-  constructor({ component, menuItems, label, types, id, root = true }) {
+  constructor(config) {
+    let { component, menuItems, label, types, id, root } = { ...defaults, ...config }
+
     if (typeof component === 'object') {
       component = React.createClass(component)
     }

--- a/src/models/BlockType.js
+++ b/src/models/BlockType.js
@@ -2,7 +2,7 @@ let React = require('react')
 
 class BlockType {
 
-  constructor({ component, menuItems, label, types, id, childOnly }) {
+  constructor({ component, menuItems, label, types, id, root = true }) {
     if (typeof component === 'object') {
       component = React.createClass(component)
     }
@@ -12,7 +12,7 @@ class BlockType {
     this.types     = types || []
     this.component = component
     this.menuItems = menuItems
-    this.childOnly = childOnly
+    this.root      = root
   }
 
   valueOf() {

--- a/src/utils/__tests__/typesForBlock.test.js
+++ b/src/utils/__tests__/typesForBlock.test.js
@@ -6,20 +6,20 @@ describe('Utils - typesForBlock', function() {
 
   describe('when not given a block', function() {
     let normal    = new BlockType({ id: 'social' })
-    let childOnly = new BlockType({ id: 'child-only', childOnly: true })
+    let root = new BlockType({ id: 'child-only', root: false })
 
-    it ('filters out childOnly blocks', function() {
-      typesForBlock([ childOnly, normal ]).should.eql([ normal ])
+    it ('filters out non-root blocks', function() {
+      typesForBlock([ root, normal ]).should.eql([ normal ])
     })
   })
 
   describe('when given a block that includes specific types', function() {
     let parent    = new BlockType({ id: 'parent', types: [ 'child-only' ] })
-    let childOnly = new BlockType({ id: 'child-only', childOnly: true })
+    let root = new BlockType({ id: 'child-only', root: false })
     let block     = new Block({ type: 'parent' })
 
-    it ('includes childOnly blocks', function() {
-      typesForBlock([ childOnly, parent ], block).should.eql([ childOnly ])
+    it ('includes root blocks', function() {
+      typesForBlock([ root, parent ], block).should.eql([ root ])
     })
   })
 

--- a/src/utils/__tests__/typesForBlock.test.js
+++ b/src/utils/__tests__/typesForBlock.test.js
@@ -1,0 +1,15 @@
+let BlockType     = require('../../models/BlockType')
+let typesForBlock = require('../typesForBlock')
+
+describe('Utils - typesForBlock', function() {
+
+  describe('when not given a block', function() {
+    let private = new BlockType({ id: 'private', private: true })
+    let social  = new BlockType({ id: 'social' })
+
+    it ('filters out private blocks', function() {
+      typesForBlock([ private, social ]).should.eql([ social ])
+    })
+  })
+
+})

--- a/src/utils/__tests__/typesForBlock.test.js
+++ b/src/utils/__tests__/typesForBlock.test.js
@@ -1,14 +1,25 @@
 let BlockType     = require('../../models/BlockType')
+let Block         = require('../../models/Block')
 let typesForBlock = require('../typesForBlock')
 
 describe('Utils - typesForBlock', function() {
 
   describe('when not given a block', function() {
-    let childOnly = new BlockType({ id: 'child-only', childOnly: true })
     let normal    = new BlockType({ id: 'social' })
+    let childOnly = new BlockType({ id: 'child-only', childOnly: true })
 
     it ('filters out childOnly blocks', function() {
       typesForBlock([ childOnly, normal ]).should.eql([ normal ])
+    })
+  })
+
+  describe('when given a block that includes specific types', function() {
+    let parent    = new BlockType({ id: 'parent', types: [ 'child-only' ] })
+    let childOnly = new BlockType({ id: 'child-only', childOnly: true })
+    let block     = new Block({ type: 'parent' })
+
+    it ('includes childOnly blocks', function() {
+      typesForBlock([ childOnly, parent ], block).should.eql([ childOnly ])
     })
   })
 

--- a/src/utils/__tests__/typesForBlock.test.js
+++ b/src/utils/__tests__/typesForBlock.test.js
@@ -4,11 +4,11 @@ let typesForBlock = require('../typesForBlock')
 describe('Utils - typesForBlock', function() {
 
   describe('when not given a block', function() {
-    let private = new BlockType({ id: 'private', private: true })
-    let social  = new BlockType({ id: 'social' })
+    let childOnly = new BlockType({ id: 'child-only', childOnly: true })
+    let normal    = new BlockType({ id: 'social' })
 
-    it ('filters out private blocks', function() {
-      typesForBlock([ private, social ]).should.eql([ social ])
+    it ('filters out childOnly blocks', function() {
+      typesForBlock([ childOnly, normal ]).should.eql([ normal ])
     })
   })
 

--- a/src/utils/typesForBlock.js
+++ b/src/utils/typesForBlock.js
@@ -8,6 +8,6 @@ module.exports = function (blockTypes, block) {
     let types = blockTypes.filter(i => i.id === block.type)[0].types
     return blockTypes.filter(i => types.indexOf(i.id) > -1)
   } else {
-    return blockTypes.filter(type => !type.private)
+    return blockTypes.filter(type => !type.childOnly)
   }
 }

--- a/src/utils/typesForBlock.js
+++ b/src/utils/typesForBlock.js
@@ -8,6 +8,6 @@ module.exports = function (blockTypes, block) {
     let types = blockTypes.filter(i => i.id === block.type)[0].types
     return blockTypes.filter(i => types.indexOf(i.id) > -1)
   } else {
-    return blockTypes.filter(type => !type.childOnly)
+    return blockTypes.filter(type => type.root)
   }
 }

--- a/src/utils/typesForBlock.js
+++ b/src/utils/typesForBlock.js
@@ -8,6 +8,6 @@ module.exports = function (blockTypes, block) {
     let types = blockTypes.filter(i => i.id === block.type)[0].types
     return blockTypes.filter(i => types.indexOf(i.id) > -1)
   } else {
-    return blockTypes
+    return blockTypes.filter(type => !type.private)
   }
 }


### PR DESCRIPTION
Adds the concept of private block types. These are block types that are only available when specifically required by a parent block.

![screen shot 2015-06-08 at 4 45 38 pm](https://cloud.githubusercontent.com/assets/590904/8044894/d04670c2-0dfd-11e5-9a60-61ba707aa004.png)

@dce, @Fosome Not sure about the nomenclature here. Thoughts?
