### PR TITLE
Fixes cursor position on change

### DIFF
--- a/addons/common/field.jsx
+++ b/addons/common/field.jsx
@@ -14,17 +14,15 @@ module.exports = React.createClass({
     }
   },
 
-  getName() {
-    return this.props.name || this.props.id
-  },
-
   render() {
-    var { label, element:Element, ...props } = this.props
+    var { label, element:Element, value, ...props } = this.props
 
     return (
       <div className="col-field">
-        <label className="col-field-label" htmlFor={ this.getName() }>{ label }</label>
-        <Element ref="input" className="col-field-input" { ...props } name={ this.getName() } />
+        <label className="col-field-label">
+          { label }
+          <Element ref="input" className="col-field-input" defaultValue={ value } { ...props } />
+        </label>
       </div>
     )
   }

--- a/style/addons/common.scss
+++ b/style/addons/common.scss
@@ -17,7 +17,6 @@ $col-field-focus-color : #009688 !default;
   display: block;
   float: none;
   font-size: 13px;
-  margin-bottom: 8px;
   width: 100%;
 }
 
@@ -27,6 +26,7 @@ $col-field-focus-color : #009688 !default;
   color: #222;
   display: block;
   font-size: 14px;
+  margin-top: 8px;
   padding-bottom: 4px;
   width: 100%;
   transition: 0.2s box-shadow;


### PR DESCRIPTION
Annoying, but for some reason controlled inputs are glitching out. This PR changes all Fields to be uncontrolled. It also wraps the field in a label instead of relying on the `for` attribute.

Fix #340

![skip](https://cloud.githubusercontent.com/assets/590904/9179729/812a94f0-3f6c-11e5-8b52-293f682fc79a.gif)
