### PR TITLE
[update] use newest, exact versions of webpack, karma, et al.

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "css-loader": "~0.16",
     "istanbul": "~0.3",
     "istanbul-instrumenter-loader": "~0.1",
-    "karma": "~>0.13.4",
+    "karma": "0.13.9",
     "karma-cli": "~0.1",
     "karma-coverage": "~0.5",
     "karma-chrome-launcher": "~0.2",
@@ -66,7 +66,7 @@
     "karma-mocha-reporter": "~1.1",
     "karma-sinon-chai": "~1.0",
     "karma-sourcemap-loader": "~0.3",
-    "karma-webpack": "~1",
+    "karma-webpack": "1.7.0",
     "mocha": "~2",
     "node-sass": "~3",
     "postcss": "~4.1",
@@ -74,8 +74,8 @@
     "react-hot-loader": "~1.2",
     "sass-loader": "~2.0",
     "style-loader": "~0.12",
-    "webpack": "~1",
-    "webpack-dev-server": "~1.10"
+    "webpack": "1.12.1",
+    "webpack-dev-server": "1.11.0"
   },
   "peerDependencies": {
     "react": ">= 0.12.1 < 0.14"


### PR DESCRIPTION
`webpack` version 1.7.3 and `webpack-dev-server` version 1.10.1 [didn't get along] ([see issue here](https://github.com/webpack/webpack/issues/1225)).(https://s3.amazonaws.com/vigesharing-is-vigecaring/lkurtz/npm_start_node_2015-09-15_15-21-02.png)

This PR updates package.json to the newest versions of these modules. It also starts defining dependencies with exact versions to avoid issues like this moving forward.

There was also [an issue](https://github.com/karma-runner/karma/issues/1497) with `karma` that necessitated a version bump along with the webpack modules.
