### PR TITLE
Adds drag and drop reordering

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,8 @@
     "microcosm": "~8.1",
     "react-focus-trap": "~0.8",
     "react-ink": "~4.1",
-    "uid": "0.0.2"
+    "uid": "0.0.2",
+    "react-dnd": "~1.1.8"
   },
   "babel": {
     "stage": 2,

--- a/src/actions/blocks.js
+++ b/src/actions/blocks.js
@@ -15,5 +15,9 @@ module.exports = {
 
   move(block, distance) {
     return { block, distance }
+  },
+
+  insertAt(block, containingBlock, preceedingBlock) {
+    return { block, containingBlock, preceedingBlock }
   }
 }

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -3,13 +3,16 @@
  * toggling between viewing modes and viewing managed content
  */
 
-let Animator    = require('./Animator')
-let Blocks      = require('../stores/Blocks')
-let EditorBlock = require('./EditorBlock')
-let React       = require('react')
-let Switch      = require('./Switch')
+let Animator        = require('./Animator')
+let Blocks          = require('../stores/Blocks')
+let EditorBlock     = require('./EditorBlock')
+let React           = require('react')
+let Switch          = require('./Switch')
+let InsertionPoint  = require('./InsertionPoint')
+let DragDropContext = require('react-dnd').DragDropContext
+let HTML5Backend    = require('react-dnd/modules/backends/HTML5')
 
-module.exports = React.createClass({
+var App = React.createClass({
 
   propTypes: {
     app : React.PropTypes.object.isRequired
@@ -26,7 +29,7 @@ module.exports = React.createClass({
 
     return (
       <div className="colonel">
-        <Switch app={ app } />
+        <InsertionPoint app={ app } />
         <Animator className="col-block-children">
           { parents.map(this.getBlock) }
         </Animator>
@@ -35,3 +38,5 @@ module.exports = React.createClass({
   }
 
 })
+
+module.exports = DragDropContext(HTML5Backend)(App)

--- a/src/components/Block.jsx
+++ b/src/components/Block.jsx
@@ -58,18 +58,14 @@ var Block = React.createClass({
     const { isDragging, connectDragSource, text } = this.props
 
     return connectDragSource(
-      <div className="col-editor-block" style={{ opacity: isDragging ? 0.5 : 1 }}>
-        <div className={ `col-block col-block-${ block.type }` }>
-          <Component ref="block" { ...block } onChange={ this._onChange } >
-            <InsertionPoint app={ app } parent={ block } preceedingBlock={ null } containingBlock={ block } />
-            <Animator className="col-block-children">
-              { children }
-            </Animator>
-          </Component>
-          <BlockMenu ref="menu" app={ app } block={ block } items={ extraMenuItems } active={ menuOpen } onOpen={ this.openMenu } onExit={ this.closeMenu } />
-        </div>
-
-        <InsertionPoint app={ app } preceedingBlock={ block } containingBlock={ block.parent } />
+      <div className={ `col-block col-block-${ block.type }` }>
+        <Component ref="block" { ...block } onChange={ this._onChange } >
+          <InsertionPoint app={ app } parent={ block } preceedingBlock={ null } containingBlock={ block } />
+          <Animator className="col-block-children">
+            { children }
+          </Animator>
+        </Component>
+        <BlockMenu ref="menu" app={ app } block={ block } items={ extraMenuItems } active={ menuOpen } onOpen={ this.openMenu } onExit={ this.closeMenu } />
       </div>
     )
   },

--- a/src/components/Block.jsx
+++ b/src/components/Block.jsx
@@ -1,15 +1,19 @@
-let Actions    = require('../actions/blocks')
-let Animator   = require('./Animator')
-let BlockMenu  = require('./BlockMenu')
-let React      = require('react')
-let Switch     = require('./Switch')
-let respondsTo = require('../utils/respondsTo')
+let React            = require('react')
+let Actions          = require('../actions/blocks')
+let Animator         = require('./Animator')
+let BlockMenu        = require('./BlockMenu')
+let InsertionPoint   = require('./InsertionPoint')
+let respondsTo       = require('../utils/respondsTo')
+let dragAndDropUtils = require('../utils/dragAndDrop')
+let DragSource       = require('react-dnd').DragSource
 
-module.exports = React.createClass({
+var Block = React.createClass({
 
   propTypes: {
     app   : React.PropTypes.object.isRequired,
-    block : React.PropTypes.object.isRequired
+    block : React.PropTypes.object.isRequired,
+    isDragging: React.PropTypes.bool.isRequired,
+    connectDragSource: React.PropTypes.func.isRequired
   },
 
   getInitialState() {
@@ -51,20 +55,21 @@ module.exports = React.createClass({
     let { component:Component } = this.getBlockType()
     let { menuOpen, extraMenuItems } = this.state
 
-    return (
-      <div className="col-editor-block">
+    const { isDragging, connectDragSource, text } = this.props
+
+    return connectDragSource(
+      <div className="col-editor-block" style={{ opacity: isDragging ? 0.5 : 1 }}>
         <div className={ `col-block col-block-${ block.type }` }>
           <Component ref="block" { ...block } onChange={ this._onChange } >
-            <Switch app={ app } parent={ block } />
+            <InsertionPoint app={ app } parent={ block } preceedingBlock={ null } containingBlock={ block } />
             <Animator className="col-block-children">
               { children }
             </Animator>
           </Component>
-
           <BlockMenu ref="menu" app={ app } block={ block } items={ extraMenuItems } active={ menuOpen } onOpen={ this.openMenu } onExit={ this.closeMenu } />
         </div>
 
-        <Switch app={ app } position={ block } parent={ block.parent } />
+        <InsertionPoint app={ app } preceedingBlock={ block } containingBlock={ block.parent } />
       </div>
     )
   },
@@ -74,3 +79,5 @@ module.exports = React.createClass({
     app.push(Actions.update, block, content)
   }
 })
+
+module.exports = DragSource('block', dragAndDropUtils.dragHandlers, dragAndDropUtils.dragCollect)(Block)

--- a/src/components/BlockSection.jsx
+++ b/src/components/BlockSection.jsx
@@ -1,0 +1,25 @@
+let React          = require('react')
+let Block          = require('./Block')
+let InsertionPoint = require('./InsertionPoint')
+
+var BlockSection = React.createClass({
+
+  propTypes: {
+    app   : React.PropTypes.object.isRequired,
+    block : React.PropTypes.object.isRequired
+  },
+
+  render() {
+    let { app, block, children } = this.props
+
+    return (
+      <div className="col-editor-block">
+        <Block app={app} block={ block } children={ children } />
+        <InsertionPoint app={ app } preceedingBlock={ block } containingBlock={ block.parent } />
+      </div>
+    )
+  }
+
+})
+
+module.exports = BlockSection

--- a/src/components/EditorBlock.jsx
+++ b/src/components/EditorBlock.jsx
@@ -1,6 +1,6 @@
-let Block  = require('./Block')
-let React  = require('react')
-let Blocks = require('../stores/Blocks')
+let BlockSection  = require('./BlockSection')
+let React         = require('react')
+let Blocks        = require('../stores/Blocks')
 
 let EditorBlock = React.createClass({
 
@@ -17,9 +17,9 @@ let EditorBlock = React.createClass({
     let { app, block } = this.props
 
     return (
-      <Block app={ app } block={ block }>
+      <BlockSection app={ app } block={ block }>
         { Blocks.getChildren(app.get('blocks'), block).map(this.getBlock) }
-      </Block>
+      </BlockSection>
     )
   }
 

--- a/src/components/InsertionPoint.jsx
+++ b/src/components/InsertionPoint.jsx
@@ -1,0 +1,63 @@
+let React               = require('react')
+let Switch              = require('./Switch')
+let classNames          = require('classnames')
+let InsertionController = require('../utils/insertionController')
+let dragAndDropUtils    = require('../utils/dragAndDrop')
+
+var DropTarget = require('react-dnd').DropTarget;
+
+var InsertionPoint = React.createClass({
+
+  propTypes: {
+    app : React.PropTypes.object.isRequired
+  },
+
+  getInitialState() {
+    return {
+      hovered: false,
+      insertAllowed: false,
+      insertDisallowed: false,
+      dropMessage: null
+    }
+  },
+
+  componentWillReceiveProps(nextProps) {
+    if (!this.props.isOver && nextProps.isOver) {
+      const insertController = new InsertionController(this.props)
+      const [insertAllowed, dropMessage] = insertController.insertAllowed(this.props.block)
+
+      this.setState({
+        hovered: true,
+        insertAllowed: insertAllowed,
+        insertDisallowed: !insertAllowed,
+        dropMessage: dropMessage
+      })
+    }
+
+    if (this.props.isOver && !nextProps.isOver) {
+      this.setState(this.getInitialState())
+    }
+  },
+
+  render() {
+    const { app, containingBlock, connectDropTarget, preceedingBlock } = this.props
+
+    const className = classNames('col-insertion-point', {
+      'col-insertion-point-hover': this.state.hovered,
+      'col-insertion-point-insert-allowed': this.state.insertAllowed,
+      'col-insertion-point-insert-disallowed': this.state.insertDisallowed
+    })
+
+    const insertController = new InsertionController(this.props)
+
+    return connectDropTarget(
+      <div className={ className } onKeyUp={ this._onKeyUp }>
+        { this.state.dropMessage }
+        <Switch app={ app } containingBlock={ containingBlock } preceedingBlock={ preceedingBlock } insertAllowed={ !insertController.full() } />
+      </div>
+    )
+  }
+
+})
+
+module.exports = DropTarget(["block"], dragAndDropUtils.dropHandlers, dragAndDropUtils.dropCollect)(InsertionPoint)

--- a/src/components/Switch.jsx
+++ b/src/components/Switch.jsx
@@ -9,7 +9,8 @@ let typesForBlock = require('../utils/typesForBlock')
 module.exports = React.createClass({
 
   propTypes: {
-    app : React.PropTypes.object.isRequired
+    app : React.PropTypes.object.isRequired,
+    insertAllowed : React.PropTypes.bool.isRequired
   },
 
   getInitialState() {
@@ -34,7 +35,7 @@ module.exports = React.createClass({
     if (this.state.open) return null
 
     return (<ActionButton ref="toggle"
-                          disabled={ this.hasMaxChildren() }
+                          disabled={ !this.props.insertAllowed }
                           label="Open the block menu and create a block"
                           onClick={ this._onToggle } />)
   },
@@ -48,25 +49,12 @@ module.exports = React.createClass({
                        onExit={ this.close } />)
   },
 
-  hasMaxChildren() {
-    let { app, parent } = this.props
-
-    if (!parent) {
-      return Blocks.filterChildren(app.get('blocks')).length >= app.get('maxChildren', Infinity)
-    }
-
-    let children = Blocks.getChildren(app.get('blocks'), parent)
-    let type     = app.refine('blockTypes').find(t => t.id === parent.type)
-
-    return children.length >= type.maxChildren
-  },
-
   render() {
-    let { app, parent, position } = this.props
-    let types = typesForBlock(app.get('blockTypes'), parent)
+    let { app, containingBlock, preceedingBlock } = this.props
+    let types = typesForBlock(app.get('blockTypes'), containingBlock)
 
     let className = classNames('col-switch', {
-      'col-switch-disabled': this.hasMaxChildren()
+      'col-switch-disabled': !this.props.insertAllowed
     })
 
     return types.length ? (
@@ -78,18 +66,18 @@ module.exports = React.createClass({
   },
 
   _onAdd(type) {
-    let { app, position, parent } = this.props
-    app.push(Actions.create, type.id, position, parent)
+    let { app, preceedingBlock, containingBlock } = this.props
+    app.push(Actions.create, type.id, preceedingBlock, containingBlock)
   },
 
   _onToggle() {
-    let { app, position, parent } = this.props
+    let { app, preceedingBlock, containingBlock } = this.props
 
-    let types = typesForBlock(app.get('blockTypes'), parent)
+    let types = typesForBlock(app.get('blockTypes'), containingBlock)
     // If only one type exists, instead of opening the nav, just
     // create that element
     if (types.length === 1) {
-      app.push(Actions.create, types[0].id, position, parent)
+      app.push(Actions.create, types[0].id, preceedingBlock, containingBlock)
     }
 
     this.open()

--- a/src/components/__tests__/Block.test.jsx
+++ b/src/components/__tests__/Block.test.jsx
@@ -4,25 +4,29 @@ let Colonel   = require('../../Colonel')
 let TestUtils = React.addons.TestUtils
 let config    = require('./fixtures/colonelConfig')
 let render    = TestUtils.renderIntoDocument
+let wrapInTestContext = require('./utils/wrapInTestContext')
+
+const BlockContext = wrapInTestContext(Block)
 
 describe('Components - Block', function() {
-  let app, component;
+  let app, component, root
 
   beforeEach(function(done) {
     app = new Colonel(config)
 
     app.start(function() {
       sinon.spy(app, 'push')
-      component = render(<Block app={ app } block={ app.get('blocks')[0] } />)
+      root = render(<BlockContext app={ app } block={ app.get('blocks')[0] } />)
+      component = TestUtils.findRenderedComponentWithType(root, Block.DecoratedComponent)
     }, done)
+
   })
 
   it ('adds a class name according to the block id', function() {
     let block   = component.props.block
     let element = React.findDOMNode(component)
-    let child   = element.querySelector('.col-block')
 
-    child.className.should.include(block.type)
+    element.className.should.include(block.type)
   })
 
   it ('sends an onOpen callback to the menu it owns', function() {

--- a/src/components/__tests__/EditorBlock.test.jsx
+++ b/src/components/__tests__/EditorBlock.test.jsx
@@ -1,8 +1,11 @@
-let Colonel     = require('../../Colonel')
-let EditorBlock = require('../EditorBlock')
-let TestUtils   = React.addons.TestUtils
-let config      = require('./fixtures/colonelConfig')
-let render      = TestUtils.renderIntoDocument
+let Colonel           = require('../../Colonel')
+let EditorBlock       = require('../EditorBlock')
+let TestUtils         = React.addons.TestUtils
+let config            = require('./fixtures/colonelConfig')
+let render            = TestUtils.renderIntoDocument
+let wrapInTestContext = require('./utils/wrapInTestContext')
+
+const EditorBlockContext = wrapInTestContext(EditorBlock)
 
 describe('Components - EditorBlock', function() {
   let app;
@@ -14,7 +17,7 @@ describe('Components - EditorBlock', function() {
 
   it ('renders child blocks', function() {
     let block = app.get('blocks')[0]
-    let component = render(<EditorBlock app={ app } block={ block } />)
+    let component = render(<EditorBlockContext app={ app } block={ block } />)
     let element = React.findDOMNode(component)
 
     element.children.length.should.equal(2)

--- a/src/components/__tests__/Switch.test.jsx
+++ b/src/components/__tests__/Switch.test.jsx
@@ -67,7 +67,7 @@ describe('Components - Switch', function() {
     })
   })
 
-  describe('When given a block with a parent', function() {
+  describe('When given a block with a containing block', function() {
     beforeEach(function(done) {
       let SecondType = Object.create(Fixture)
 
@@ -84,14 +84,14 @@ describe('Components - Switch', function() {
     })
 
     it ('getTypes should display multiple blocks', function() {
-      let component = render(<Switch app={ app } parent={ app.get('blocks')[0] }/>)
+      let component = render(<Switch app={ app } containingBlock={ app.get('blocks')[0] }/>)
 
       component.setState({ open : true })
       component.getDOMNode().querySelectorAll('button').length.should.be.gt(1)
     })
   })
 
-  describe('When given a block with a parent that has no types', function() {
+  describe('When given a block with a containing block that has no types', function() {
     beforeEach(function(done) {
       app = new Colonel({
         el : document.createElement('div'),
@@ -103,7 +103,7 @@ describe('Components - Switch', function() {
     })
 
     it ('renders nothing', function() {
-      let component = render(<Switch app={ app } parent={ app.get('blocks')[0] }/>)
+      let component = render(<Switch app={ app } containingBlock={ app.get('blocks')[0] } insertAllowed={ false } />)
       expect(component.getDOMNode()).to.equal(null)
     })
   })
@@ -152,7 +152,7 @@ describe('Components - Switch', function() {
     })
 
     it ('does not enable toggles when its provided block has too many children', function() {
-      let el = render(<Switch app={ app } parent={ app.get('blocks')[0] } />)
+      let el = render(<Switch app={ app } containingBlock={ app.get('blocks')[0] } />)
       el.getDOMNode().querySelector('button').disabled.should.equal(true)
     })
   })

--- a/src/components/__tests__/utils/wrapInTestContext.js
+++ b/src/components/__tests__/utils/wrapInTestContext.js
@@ -1,0 +1,13 @@
+import { Component } from 'react'
+import TestBackend from 'react-dnd/modules/backends/Test'
+import { DragDropContext } from 'react-dnd'
+
+module.exports = function wrapInTestContext(DecoratedComponent) {
+  return DragDropContext(TestBackend)(
+    class TestContextContainer extends Component {
+      render() {
+        return <DecoratedComponent {...this.props} />
+      }
+    }
+  )
+}

--- a/src/stores/Blocks.js
+++ b/src/stores/Blocks.js
@@ -15,10 +15,11 @@ let siblingAt  = require('../utils/siblingAt')
 let Blocks = {
   register() {
     return {
-      [Actions.create]  : this.create,
-      [Actions.destroy] : this.destroy,
-      [Actions.update]  : this.update,
-      [Actions.move]    : this.move
+      [Actions.create]   : this.create,
+      [Actions.destroy]  : this.destroy,
+      [Actions.update]   : this.update,
+      [Actions.move]     : this.move,
+      [Actions.insertAt] : this.insertAt
     }
   },
 
@@ -84,6 +85,16 @@ let Blocks = {
     let before  = siblingAt(state, block, distance)
 
     return insertAt(without, block, state.indexOf(before))
+  },
+
+  insertAt(state, { block, containingBlock, preceedingBlock }) {
+    block.parent = containingBlock
+    if (!preceedingBlock) preceedingBlock = containingBlock
+    let currentPosition = state.indexOf(block)
+    let newPosition = (state.indexOf(preceedingBlock) + 1)
+    if (currentPosition < newPosition) newPosition -= 1
+    let otherBlocks = state.filter(i => i !== block)
+    return insertAt(otherBlocks, block, newPosition)
   }
 }
 

--- a/src/utils/dragAndDrop.js
+++ b/src/utils/dragAndDrop.js
@@ -1,0 +1,56 @@
+let Actions             = require('../actions/blocks')
+let InsertionController = require('../utils/insertionController')
+
+module.exports = {
+  dropHandlers:  {
+    canDrop: function(props, monitor) {
+      const block = monitor.getItem().block
+      const insertController = new InsertionController(props)
+      const [result, message] = insertController.insertAllowed(block)
+
+      return result
+    },
+
+    drop: function (props, monitor, component) {
+      if (monitor.didDrop() || !monitor.canDrop()) return;
+
+      const item = monitor.getItem()
+      const app = item.app
+      const block = item.block
+      const { containingBlock, preceedingBlock } = props
+
+      app.push(Actions.insertAt, block, containingBlock, preceedingBlock)
+
+      return { moved: true }
+    }
+  },
+
+  dropCollect: function(connect, monitor) {
+    let item = monitor.getItem() || {}
+
+    return {
+      block: item.block,
+      canDrop: monitor.canDrop(),
+      connectDropTarget: connect.dropTarget(),
+      isOver: monitor.isOver(),
+      isOverCurrent: monitor.isOver({ shallow: true }),
+      itemType: monitor.getItemType()
+    }
+  },
+
+  dragHandlers: {
+    beginDrag: function(props) {
+      return {
+        block: props.block,
+        app: props.app
+      }
+    }
+  },
+
+  dragCollect: function collect(connect, monitor) {
+    return {
+      connectDragSource: connect.dragSource(),
+      isDragging: monitor.isDragging()
+    }
+  }
+}

--- a/src/utils/insertionController.js
+++ b/src/utils/insertionController.js
@@ -23,7 +23,7 @@ module.exports = class InsertionController {
       message = "Can't drop here. The containing block is full."
     } else {
       allowed = true
-      message = "Drop away!"
+      message = null
     }
 
     return [allowed, message]

--- a/src/utils/insertionController.js
+++ b/src/utils/insertionController.js
@@ -1,0 +1,62 @@
+let Blocks        = require('../stores/Blocks')
+let typesForBlock = require('../utils/typesForBlock')
+
+module.exports = class InsertionController {
+
+  constructor(props) {
+    this.props = props
+  }
+
+  insertAllowed(block) {
+    if (!block) return [false, "Must provide a block."]
+    const type = block.type
+
+    let message = null
+    let allowed = false
+
+    if(this.containerIsSelf(block)) {
+      // TODO: i18n these messages
+      message = "Can't drop here. You can't drop a block into itself."
+    } else if(!this.typeAllowed(type)) {
+      message = "Can't drop here. This type is disallowed by the containing block."
+    } else if (this.full() && !this.intrablockMove(block)) {
+      message = "Can't drop here. The containing block is full."
+    } else {
+      allowed = true
+      message = "Drop away!"
+    }
+
+    return [allowed, message]
+  }
+
+  containerIsSelf(block) {
+    const { containingBlock } = this.props
+    return(block === containingBlock)
+  }
+
+  typeAllowed(type) {
+    const { app, containingBlock } = this.props
+    const allowedTypes = typesForBlock(app.get('blockTypes'), containingBlock).map((type) => type.id)
+    return(allowedTypes.indexOf(type) !== -1)
+  }
+
+  full() {
+    const { app, containingBlock } = this.props
+
+    if (!containingBlock) {
+      const maxRootBlocks = app.get('maxChildren', Infinity)
+      return Blocks.filterChildren(app.get('blocks')).length >= maxRootBlocks
+    }
+
+    const childBlocks = Blocks.getChildren(app.get('blocks'), containingBlock)
+    const type = app.refine('blockTypes').find(type => type.id === containingBlock.type)
+
+    return childBlocks.length >= type.maxChildren
+  }
+
+  intrablockMove(block) {
+    const { containingBlock } = this.props
+    return (block.parent === this.props.containingBlock)
+  }
+
+}

--- a/style/colonel.scss
+++ b/style/colonel.scss
@@ -27,5 +27,6 @@
   @import 'components/menu';
   @import 'components/switch';
   @import 'components/button';
+  @import 'components/insertion-point';
   @import 'utilities';
 }

--- a/style/components/insertion-point.scss
+++ b/style/components/insertion-point.scss
@@ -1,0 +1,24 @@
+/**
+ * Insertion Point
+ * An Insertion Point is where a new block may be added, or an existing block moved
+ */
+
+.col-insertion-point {
+  border: none;
+  color: $col-text;
+  font-size: unit(3);
+
+  &.col-insertion-point-hover {
+    border: 3px dotted $col-secondary;
+    margin: unit(3);
+    padding: unit(3);
+
+    &.col-insertion-point-insert-allowed {
+      border-color: $col-primary;
+    }
+
+    &.col-insertion-point-insert-disallowed {
+      border-color: $col-warning;
+    }
+  }
+}

--- a/style/components/switch.scss
+++ b/style/components/switch.scss
@@ -12,6 +12,12 @@ $col-switch-btn-width   : unit(11) !default;
 $col-switch-btn-border  : rgba(#000, 0.15) !default;
 $col-switch-nav-radius  : 3px !default;
 
+.col-insertion-point-hover {
+  .col-switch {
+    display: none;
+  }
+}
+
 .col-switch {
   padding: $col-switch-padding;
   text-align: center;

--- a/style/values/colors.scss
+++ b/style/values/colors.scss
@@ -25,3 +25,4 @@ $col-primary: $theme-primary !default;
 $col-backdrop: #eee !default;
 $col-text: $theme-text !default;
 $col-secondary-text: $theme-secondary-text !default;
+$col-warning: #96000e;


### PR DESCRIPTION
Tests are forthcoming. Keep an eye our for that PR soon.

This adds a drag and drop reordering interaction. The interaction respects existing block type restrictions and child block maximums. See demo below.

Right now you can just click and drag a block from anywhere, but we could change that if we find it annoying.

![demo](https://s3.amazonaws.com/vigesharing-is-vigecaring/lkurtz/ck-dragon-demo-drag-2.gif)
