### PR TITLE
Filtering blocks passed in for CK consumption

### DIFF
--- a/src/plugins/__tests__/bootstrap.test.js
+++ b/src/plugins/__tests__/bootstrap.test.js
@@ -13,7 +13,9 @@ describe('bootstrap plugin', function() {
       type    : 'section'
     }])
 
-    bootstrap.register(app, { blocks: input, blockTypes: [] }, function() {
+    let blockTypes = [{ id: 'section' }]
+
+    bootstrap.register(app, { blocks: input, blockTypes }, function() {
       app.refine('blocks').first().should.have.property('type', 'section')
       done()
     })
@@ -42,6 +44,73 @@ describe('bootstrap plugin', function() {
       blockTypes : [{ id: 'list' }, { id: 'text' }]
     }, function() {
       app.refine('blockTypes').size().should.equal(2)
+      done()
+    })
+  })
+
+  it ('filters out blocks which have a type not passed in to blockTypes', function(done) {
+    let app   = new Colonel({ el : document.createElement('div') })
+    let input = document.createElement('textarea')
+
+    input.value = JSON.stringify([
+      {
+        blocks  : [],
+        content : {},
+        type    : 'list'
+      },
+      {
+        blocks  : [],
+        content : {},
+        type    : 'section'
+      }
+    ])
+
+    bootstrap.register(app, {
+      blocks     : input,
+      blockTypes : [{ id: 'list' }]
+    }, function() {
+      let blocks = app.refine('blocks')
+
+      blocks.size().should.equal(1)
+      blocks.first().type.should.equal('list')
+
+      done()
+    })
+  })
+
+  it ('filters out children blocks which have a type not passed in to blockTypes', function(done) {
+    let app   = new Colonel({ el : document.createElement('div') })
+    let input = document.createElement('textarea')
+
+    input.value = JSON.stringify([
+      {
+        content : {},
+        type    : 'list',
+        blocks  : [
+          {
+            blocks  : [],
+            content : {},
+            type    : 'text'
+          },
+          {
+            blocks  : [],
+            content : {},
+            type    : 'alien'
+          }
+        ]
+      }
+    ])
+
+    bootstrap.register(app, {
+      blocks     : input,
+      blockTypes : [{ id: 'list' }, { id: 'text' }]
+    }, function() {
+      let blocks = app._state.blocks
+
+      blocks.length.should.equal(2)
+      blocks[0].type.should.equal('list')
+      blocks[1].type.should.equal('text')
+
       done()
     })
   })

--- a/src/plugins/bootstrap.js
+++ b/src/plugins/bootstrap.js
@@ -22,9 +22,18 @@ module.exports = {
   },
 
   filterBlocks(blocks, blockTypes) {
-    var types = blockTypes.map(blockType => blockType.id)
+    var _this = this
+    var typeWhitelist = blockTypes.map(blockType => blockType.id)
+    var validBlocks   = []
 
-    return blocks.filter(block => types.indexOf(block.type) > -1)
+    blocks.forEach(function(block) {
+      if (typeWhitelist.indexOf(block.type) > -1) {
+        block.blocks = _this.filterBlocks(block.blocks, blockTypes)
+        validBlocks  = validBlocks.concat(block)
+      }
+    })
+
+    return validBlocks
   },
 
   register(app, { allow, maxChildren, blocks, blockTypes }, next) {
@@ -32,7 +41,7 @@ module.exports = {
 
     if (blocks instanceof HTMLElement) {
       blocks = parseElement(blocks)
-      blocks = filterBlocks(blocks, blockTypes)
+      blocks = this.filterBlocks(blocks, blockTypes)
     }
 
     app.replace({ blocks, blockTypes })

--- a/src/plugins/bootstrap.js
+++ b/src/plugins/bootstrap.js
@@ -15,18 +15,27 @@ let parseElement = function (element) {
 
 module.exports = {
 
-  filter(blockTypes, acceptable) {
+  filterBlockTypes(blockTypes, acceptable) {
     if (!acceptable) return blockTypes
 
     return blockTypes.filter(type => acceptable.indexOf(type.id) > -1)
   },
 
+  filterBlocks(blocks, blockTypes) {
+    var types = blockTypes.map(blockType => blockType.id)
+
+    return blocks.filter(block => types.indexOf(block.type) > -1)
+  },
+
   register(app, { allow, maxChildren, blocks, blockTypes }, next) {
+    blockTypes = this.filterBlockTypes(blockTypes, allow)
+
     if (blocks instanceof HTMLElement) {
       blocks = parseElement(blocks)
+      blocks = filterBlocks(blocks, blockTypes)
     }
 
-    app.replace({ blocks, blockTypes: this.filter(blockTypes, allow) })
+    app.replace({ blocks, blockTypes })
 
     app.set('maxChildren', maxChildren)
 


### PR DESCRIPTION
Only passing in blocks which have an allowed type.

Using recursion to build the valid blocks:
- filter the first level of blocks
- for all that are of a valid type, filter their children list with the same function, then add to the valid list
- return the valid list
