### PR TITLE
Nh client only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 3.1.0
+
+- Added a `clientOnly` property to blocks. This is a boolean property
+  indicating if the block was created by the user during the current
+  editing session (as opposed to being present when the editor starts).
+
 ## 3.0.0
 
 - **Important Update**: This update makes breaking changes to support

--- a/docs/blocks.md
+++ b/docs/blocks.md
@@ -3,8 +3,9 @@
 A block is the atomic organizational unit for Colonel Kurtz. It has
 several properties:
 
-Property | Description
--------- | -----------
-content  | A JavaScript object containing properties of the block, this could include src for an image, html from a rich text editor, etc
-type     | How to display a block, must be of a preconfigured Block Type. Within Colonel, it controls the editing experience for a block.
-blocks   | Children of the block, useful for nesting content inside of other content
+Property   | Description
+---------- | -----------
+content    | An object containing properties of the block, this could include src for an image, html from a rich text editor, etc.
+type       | How to display a block, must be of a preconfigured Block Type. Within Colonel, it controls the editing experience for a block.
+blocks     | Children of the block, useful for nesting content inside of other content.
+clientOnly | Boolean. True if the block was created during the current editing session.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "colonel-kurtz",
-  "version": "3.0.0",
+  "version": "3.1.0-alpha",
   "private": true,
   "description": "A block editor",
   "main": "src/Colonel.js",

--- a/src/__tests__/Colonel.test.js
+++ b/src/__tests__/Colonel.test.js
@@ -36,6 +36,10 @@ describe('ColonelKurtz', function() {
       app.refine('blocks').first().type.should.equal('section')
     })
 
+    it ('should flag the block as client-only', function() {
+      app.refine('blocks').first().clientOnly.should.equal(true)
+    })
+
   })
 
   describe('when a destroy action is sent to the app', function() {

--- a/src/models/Block.js
+++ b/src/models/Block.js
@@ -3,10 +3,11 @@ let uid = require('../utils/uid')
 class Block {
 
   constructor(params) {
-    this.id      = uid()
-    this.content = params.content || {}
-    this.parent  = params.parent
-    this.type    = params.type
+    this.id         = uid()
+    this.content    = params.content || {}
+    this.parent     = params.parent
+    this.type       = params.type
+    this.clientOnly = params.clientOnly || false
   }
 
   valueOf() {

--- a/src/stores/Blocks.js
+++ b/src/stores/Blocks.js
@@ -51,7 +51,7 @@ let Blocks = {
   deserialize: require('../utils/jsonToBlocks'),
 
   create(state, { type, parent, position }) {
-    let record = new Block({ parent, type })
+    let record = new Block({ clientOnly: true, parent, type })
 
     // If the provided position is a Block, place the new block right
     // after it.

--- a/src/utils/__tests__/blocksToJson.test.js
+++ b/src/utils/__tests__/blocksToJson.test.js
@@ -12,6 +12,14 @@ describe('Utils - blocksToJson', function() {
     result[0].blocks.length.should.equal(2)
   })
 
+  it ('does not include clientOnly flags', function() {
+    let parent = new Block({})
+    let blocks = [ parent, new Block({ parent }), new Block({ parent }) ]
+    let result = blocksToJson(blocks)
+
+    result.should.not.have.property('clientOnly')
+  })
+
   it ('just returns an empty object if no value is given', function() {
     blocksToJson().length.should.equal(0)
   })


### PR DESCRIPTION
I let this one drag by... This PR adds a `clientOnly` boolean property to Blocks. Whenever a block is created on the client-side, it will equal `true`.

This is available for testing on NPM at : `colonel-kurtz@3.1.0-alpha`