### PR TITLE
HTML Embed Block

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 npm-debug.log
 coverage
 dist
+.happypack

--- a/addons/html-embed/README.md
+++ b/addons/html-embed/README.md
@@ -33,4 +33,4 @@ the `blockTypes` field:
 
 ## Considerations
 
-`<script>` and `<style>` tags will be automatically stripped out of HTML input.
+`<script>` and `<style>` tags will be automatically stripped out of HTML input.  The server should do the same as the JSON coming out of the HTML Embed block could be modified.

--- a/addons/html-embed/README.md
+++ b/addons/html-embed/README.md
@@ -1,0 +1,36 @@
+# HTML Embed Addon
+
+1. [Overview](#overview)
+2. [Integration](#integration)
+3. [Data Format](#data-format)
+
+## Overview
+
+This component may be used to include HTML and accompanying scripts within Colonel Kurtz.
+
+## Integration
+
+When creating a Colonel Kurtz instance, pass the following entry into
+the `blockTypes` field:
+
+    let editor = new ColonelKurtz({
+      ...
+      blockTypes : [
+        {
+          id        : 'html-embed',
+          label     : 'HTML Embed',
+          component : require('colonel-kurtz/addons/html-embed')
+        }
+      ]
+    })
+
+## Data Format
+
+    {
+      "html"   : string,
+      "script" : string
+    }
+
+## Considerations
+
+`<script>` and `<style>` tags will be automatically stripped out of HTML input.

--- a/addons/html-embed/__tests__/html-embed.test.jsx
+++ b/addons/html-embed/__tests__/html-embed.test.jsx
@@ -1,0 +1,78 @@
+const HtmlEmbed = require('../index')
+const Simulate  = TestUtils.Simulate
+const render    = TestUtils.renderIntoDocument
+const DOM       = require('react-dom')
+
+describe('Addons - HTML Embed', function() {
+
+  context('instantiating the component', function() {
+    beforeEach(function() {
+      this.encoding = 'data:text/html;charset=utf-8'
+    })
+
+    context('when no HTML or script is provided', function() {
+      beforeEach(function() {
+        this.component = render(<HtmlEmbed/>)
+      })
+
+      it('does not render the sandbox', function() {
+        const iframes = TestUtils.scryRenderedDOMComponentsWithTag(this.component, 'iframe')
+
+        iframes.length.should.equal(0)
+      })
+    })
+
+    context('when HTML is provided', function() {
+      beforeEach(function() {
+        this.content   = { html: '<p>Arbitrary html</p>' }
+        this.component = render(<HtmlEmbed content={ this.content } />)
+      })
+
+      it('renders the sandbox', function() {
+        const iframes = TestUtils.scryRenderedDOMComponentsWithTag(this.component, 'iframe')
+
+        iframes.length.should.equal(1)
+
+        iframes[0].src.should.include(this.encoding)
+        iframes[0].src.should.include(escape(this.content.html))
+      })
+    })
+
+    context('when a script is provided', function() {
+      beforeEach(function() {
+        this.content        = { script: 'https://scripts.net/such-wow' }
+        this.component      = render(<HtmlEmbed content={ this.content } />)
+        this.expectedScript = escape('<script src="https://scripts.net/such-wow" async></script>')
+      })
+
+      it('renders the sandbox', function() {
+        const iframes = TestUtils.scryRenderedDOMComponentsWithTag(this.component, 'iframe')
+
+        iframes.length.should.equal(1)
+
+        iframes[0].src.should.include(this.encoding)
+        iframes[0].src.should.include(this.expectedScript)
+      })
+    })
+  })
+
+  context('on an existing component', function() {
+    context('when given HTML', function() {
+      context('containing potentially dangerous tags (script/style)', function() {
+        it('sanitizes HTML when the user inputs markup', function(done) {
+          function didStripStyleTags (content) {
+            content.html.should.not.include('<style')
+            content.html.should.not.include('<script')
+            done()
+          }
+
+          var component = render(<HtmlEmbed onChange={ didStripStyleTags } />)
+          var content   = '<style>body{}</style><p>Test</p><script src="https://such-script.com/wow"></script>'
+
+          Simulate.change(component.refs.html.refs.input, { target: { value: content } })
+        })
+      })
+    })
+  })
+
+})

--- a/addons/html-embed/index.jsx
+++ b/addons/html-embed/index.jsx
@@ -1,0 +1,79 @@
+/**
+ * HTML Embed
+ * A reuseable element for embedding HTML and associated JS.
+ */
+
+const Field   = require('../common/field')
+const React   = require('react')
+const toArray = list => Array.prototype.slice.call(list)
+
+function sanitize (html) {
+  let bucket = document.createElement('div')
+
+  bucket.innerHTML = html
+
+  let doNotAllow = toArray(bucket.querySelectorAll('script, style'))
+
+  doNotAllow.forEach(el => el.parentNode.removeChild(el))
+
+  return bucket.innerHTML
+}
+
+module.exports = React.createClass({
+
+  getDefaultProps() {
+    return {
+      content: {
+        html:   '',
+        script: ''
+      }
+    }
+  },
+
+  shouldDisplaySandbox() {
+    return this.props.content.html || this.props.content.script
+  },
+
+  getSandbox() {
+    let { html = '', script = '' } = this.props.content
+
+    let encoding   = "data:text/html;charset=utf-8,"
+    let javascript = `<script src="${ script }" async></script>`
+    let embeddable = encoding + escape(html + javascript)
+
+    return <iframe className="col-block-frame" src={ embeddable } />
+  },
+
+  render() {
+    let { html, script } = this.props.content
+
+    return (
+      <div>
+        <Field className="col-block-html"
+               label="HTML Embed"
+               element="textarea"
+               hint="Paste HTML into this field. Include related JavaScript below."
+               ref="html"
+               value={ html }
+               onChange={ this.onHTMLChange } />
+
+        <Field label="Embedded JavaScript URL"
+               hint="Paste the JavaScript URL of the embed into this field."
+               ref="script"
+               value={ script }
+               onChange={ this.onScriptChange } />
+
+        { this.shouldDisplaySandbox() ? this.getSandbox() : null }
+      </div>
+    )
+  },
+
+  onScriptChange(event) {
+    this.props.onChange({ script: event.target.value })
+  },
+
+  onHTMLChange(event) {
+    this.props.onChange({ html: sanitize(event.target.value) })
+  }
+
+})

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,4 +1,5 @@
 var Webpack        = require('webpack')
+var HappyPack      = require('happypack')
 var webpack_config = require('./webpack.config')
 var isIntegration  = process.env.CONTINUOUS_INTEGRATION === 'true'
 var noCoverage     = process.env.NO_COVERAGE === 'true'
@@ -52,7 +53,9 @@ module.exports = function(config) {
         new Webpack.ProvidePlugin({
           React     : 'react',
           TestUtils : 'react-addons-test-utils'
-        })
+        }),
+
+        new HappyPack({ id: 'js' })
       ],
 
       resolve: webpack_config.resolve,
@@ -62,23 +65,21 @@ module.exports = function(config) {
           {
             test    : /\.jsx*$/,
             exclude : /node_modules/,
-            loader  : 'babel',
-            query   : {
-              auxiliaryCommentBefore: "istanbul ignore next",
-              optional: [ 'runtime' ]
-            }
+            loader  : 'babel?optional=runtime',
+            happy   : { id: 'js' }
           }
         ],
         postLoaders: noCoverage ? [] : [{
-          test: /\.jsx*$/,
-          exclude: /(__tests__|node_modules)/,
-          loader: 'istanbul-instrumenter'
+          test    : /\.jsx*$/,
+          happy   : { id: 'js' },
+          exclude : /(__tests__|node_modules)/,
+          loader  : 'istanbul-instrumenter'
         }]
-      }
-    },
+      },
 
-    webpackServer: {
-      noInfo: true
+      webpackServer: {
+        noInfo: true
+      }
     }
   });
 };

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "babel-runtime": "~5",
     "coveralls": "~2",
     "css-loader": "~0.16",
+    "happypack": "2.1.0",
     "istanbul": "~0.3",
     "istanbul-instrumenter-loader": "~0.1",
     "karma": "0.13.9",

--- a/style/addons/html-embed.scss
+++ b/style/addons/html-embed.scss
@@ -1,0 +1,30 @@
+/**
+ * HTML Embed Block Type
+ */
+
+.col-block-html {
+  padding-top: 8px;
+
+  .col-block-html {
+    background: #223;
+    border-radius: 3px;
+    border: 1px solid #222;
+    box-shadow: inset 0 1px 5px rgba(black, 0.4);
+    color: #eef;
+    font-family: monospace;
+    font-size: 14px;
+    height: 72px;
+    line-height: 1.7;
+    margin: 8px 0 4px;
+    padding: 4px 12px;
+    width: 100%;
+    word-break: break-all;
+  }
+
+  .col-block-frame {
+    border: 0;
+    min-height: 350px;
+    width: 100%;
+  }
+
+}


### PR DESCRIPTION
This PR introduces a new HTML Embed block as an addon in Colonel Kurtz.  It allows users to input HTML and an accompanying script.  Shamelessly ripped from WCS.

Also pulls in `happypack`.