### PR TITLE
Blocks should start with default content

### DIFF
--- a/src/components/Block.jsx
+++ b/src/components/Block.jsx
@@ -48,9 +48,14 @@ module.exports = React.createClass({
 
   componentDidMount() {
     this.setMenuItems(this.refs.block)
+
+    // Trigger an initial change to ensure default content
+    // is assigned immediately
+    this._onChange(this.getContent(this.props.block))
   },
 
-  getContent(block, component) {
+  getContent(block) {
+    let { component } = this.getBlockType()
     let defaults = typeof component.getDefaultProps === 'function' ? component.getDefaultProps() : {}
 
     return { ...defaults.content, ...block.content }
@@ -63,7 +68,7 @@ module.exports = React.createClass({
 
     // Determine content by taking the default content and extend it with
     // the current block content
-    let content = this.getContent(block, Component)
+    let content = this.getContent(block)
 
     return (
       <div className="col-editor-block">

--- a/src/components/__tests__/Block.test.jsx
+++ b/src/components/__tests__/Block.test.jsx
@@ -18,6 +18,12 @@ describe('Components - Block', function() {
     })
   })
 
+  it ('assigns default content to the block', function() {
+    let block = component.props.block
+
+    block.content.text.should.equal('Test')
+  })
+
   it ('adds a class name according to the block id', function() {
     let block   = component.props.block
     let element = DOM.findDOMNode(component)


### PR DESCRIPTION
Before this commit, default content would only be assigned to a block as it was changed. This commit fires an update event when the block mounts that ensures this default content is assigned.

Long term, I would like this to happen outside of the view layer. However this appears to be the best place to put it within the current system.
