### PR TITLE
Replace React component string refs with callback

### DIFF
--- a/addons/common/__tests__/embedded.test.jsx
+++ b/addons/common/__tests__/embedded.test.jsx
@@ -36,7 +36,7 @@ describe('Addons - Common - Embedded', function() {
   it ('closes the frame if no slug is given', function() {
     const component = render(<Embedded name="test" onChange={ sinon.stub() } />)
 
-    component.refs.frame.props.open.should.equal(false)
+    component.frame.props.open.should.equal(false)
   })
 
   it ('fires a change event with a key/value pair according to the given name', function(done) {
@@ -47,7 +47,7 @@ describe('Addons - Common - Embedded', function() {
 
     const component = render(<Embedded name="test" onChange={ test } slug="1" />)
 
-    Simulate.change(DOM.findDOMNode(component.refs.field.refs.input))
+    Simulate.change(DOM.findDOMNode(component.field.input))
   })
 
 })

--- a/addons/common/__tests__/field.test.jsx
+++ b/addons/common/__tests__/field.test.jsx
@@ -5,13 +5,13 @@ const DOM    = require('react-dom')
 describe('Addons - Common - Field', function () {
   it ('defaults to input element', function() {
     let component = render(<Field />)
-    let tag = DOM.findDOMNode(component.refs.input).tagName
+    let tag = DOM.findDOMNode(component.input).tagName
     tag.should.equal('INPUT')
   })
 
   it ('uses element instead of input if provided', function() {
     let component = render(<Field element='textarea' />)
-    let tag = DOM.findDOMNode(component.refs.input).tagName
+    let tag = DOM.findDOMNode(component.input).tagName
 
     tag.should.equal('TEXTAREA')
   })
@@ -19,7 +19,7 @@ describe('Addons - Common - Field', function () {
   it ('passes props through to the input ref', function() {
     let component = render(<Field type="number" />)
 
-    component.refs.input.type.should.equal('number')
+    component.input.type.should.equal('number')
   })
 
   it ('sets up aria-describeby for hints', function() {

--- a/addons/common/embedded.jsx
+++ b/addons/common/embedded.jsx
@@ -44,9 +44,9 @@ const Embedded = React.createClass({
 
     return (
       <div className={ className }>
-        <Field ref="field" hint={ hint } label={ title } value={ slug } name={ name } onChange={ this._onChange } />
+        <Field ref={ (el) => this.field = el } hint={ hint } label={ title } value={ slug } name={ name } onChange={ this._onChange } />
         { this.props.children }
-        <Frame ref="frame" open={ this.hasSlug() }>
+        <Frame ref={ (el) => this.frame = el } open={ this.hasSlug() }>
           <Graphic key={ slug } element="iframe" src={ this.getSrc(slug) } />
         </Frame>
       </div>

--- a/addons/common/field.jsx
+++ b/addons/common/field.jsx
@@ -34,7 +34,7 @@ let Field = React.createClass({
       <label className="col-field">
         <span className="col-field-label">{ label }</span>
 
-        <Element ref="input" className="col-field-input" aria-describedby={ hint ? hintId : null } { ...props } />
+        <Element ref={ (el) => this.input = el } className="col-field-input" aria-describedby={ hint ? hintId : null } { ...props } />
         { this.getHint(hint) }
       </label>
     )

--- a/addons/html-embed/__tests__/html-embed.test.jsx
+++ b/addons/html-embed/__tests__/html-embed.test.jsx
@@ -69,7 +69,7 @@ describe('Addons - HTML Embed', function() {
           var component = render(<HtmlEmbed onChange={ didStripStyleTags } />)
           var content   = '<style>body{}</style><p>Test</p><script src="https://such-script.com/wow"></script>'
 
-          Simulate.change(component.refs.html.refs.input, { target: { value: content } })
+          Simulate.change(component.html.input, { target: { value: content } })
         })
       })
     })

--- a/addons/html-embed/index.jsx
+++ b/addons/html-embed/index.jsx
@@ -54,13 +54,13 @@ module.exports = React.createClass({
                label="HTML Embed"
                element="textarea"
                hint="Paste HTML into this field. Include related JavaScript below."
-               ref="html"
+               ref={ (el) => this.html = el }
                value={ html }
                onChange={ this.onHTMLChange } />
 
         <Field label="Embedded JavaScript URL"
                hint="Paste the JavaScript URL of the embed into this field."
-               ref="script"
+               ref={ (el) => this.script = el }
                value={ script }
                onChange={ this.onScriptChange } />
 

--- a/addons/medium/index.jsx
+++ b/addons/medium/index.jsx
@@ -36,7 +36,7 @@ var Medium = React.createClass({
 
   componentDidMount() {
     this.setState({
-      editor: new MediumEditor(DOM.findDOMNode(this.refs.editor), this.props.options)
+      editor: new MediumEditor(DOM.findDOMNode(this.editor), this.props.options)
     })
   },
 
@@ -47,14 +47,14 @@ var Medium = React.createClass({
   render() {
     return (
       <div className="col-block-medium">
-        <div className="col-medium" onBlur={ this._onBlur } role="textarea" aria-multiline="true" ref="editor" dangerouslySetInnerHTML={{ __html: this.props.content.html }} />
+        <div className="col-medium" onBlur={ this._onBlur } role="textarea" aria-multiline="true" ref={ (el) => this.editor = el } dangerouslySetInnerHTML={{ __html: this.props.content.html }} />
         { this.props.children }
       </div>
     )
   },
 
   _onBlur() {
-    var editor = DOM.findDOMNode(this.refs.editor)
+    var editor = DOM.findDOMNode(this.editor)
 
     this.props.onChange({
       text: editor.textContent,

--- a/src/components/Block.jsx
+++ b/src/components/Block.jsx
@@ -47,7 +47,7 @@ module.exports = React.createClass({
   },
 
   componentDidMount() {
-    this.setMenuItems(this.refs.block)
+    this.setMenuItems(this.block)
 
     // Trigger an initial change to ensure default content
     // is assigned immediately
@@ -73,14 +73,14 @@ module.exports = React.createClass({
     return (
       <div className="col-editor-block">
         <div className={ `col-block col-block-${ block.type }` }>
-          <Component ref="block" { ...block } content={ content } onChange={ this._onChange } >
+          <Component ref={ (el) => this.block = el } { ...block } content={ content } onChange={ this._onChange } >
             <Switch app={ app } parent={ block } />
             <Animator className="col-block-children">
               { children }
             </Animator>
           </Component>
 
-          <BlockMenu ref="menu" app={ app } block={ block } items={ extraMenuItems } active={ menuOpen } onOpen={ this.openMenu } onExit={ this.closeMenu } />
+          <BlockMenu ref={ (el) => this.menu = el } app={ app } block={ block } items={ extraMenuItems } active={ menuOpen } onOpen={ this.openMenu } onExit={ this.closeMenu } />
         </div>
 
         <Switch app={ app } position={ block } parent={ block.parent } />

--- a/src/components/BlockMenu.jsx
+++ b/src/components/BlockMenu.jsx
@@ -22,7 +22,7 @@ module.exports = React.createClass({
 
   getMenuItem(item) {
     let { id } = item
-    return (<Item key={ id } ref={ id } { ...item } { ...this.props } />)
+    return (<Item key={ id } ref={ (el) => this[id] = el } { ...item } { ...this.props } />)
   },
 
   getMenuItems() {
@@ -45,7 +45,7 @@ module.exports = React.createClass({
   render() {
     return (
       <Animator className="col-menu-wrapper" transitionName="col-menu" transitionEnterTimeout={ 300 } transitionLeaveTimeout={ 200 }>
-        <Handle key="handle" ref="handle" onClick={ this.props.onOpen }/>
+        <Handle key="handle" ref={ (el) => this.handle = el } onClick={ this.props.onOpen }/>
         { this.getMenu() }
       </Animator>
     )

--- a/src/components/Switch.jsx
+++ b/src/components/Switch.jsx
@@ -26,14 +26,14 @@ module.exports = React.createClass({
 
   close() {
     this.setState({ open: false }, () => {
-      this.refs.toggle.focus()
+      this.toggle.focus()
     })
   },
 
   getToggle() {
     if (this.state.open) return null
 
-    return (<ActionButton ref="toggle"
+    return (<ActionButton ref={ (el) => this.toggle = el }
                           disabled={ this.hasMaxChildren() }
                           label="Open the block menu and create a block"
                           onClick={ this._onToggle } />)
@@ -42,7 +42,7 @@ module.exports = React.createClass({
   getNav(blockTypes) {
     if (!this.state.open) return null
 
-    return (<SwitchNav ref="nav"
+    return (<SwitchNav ref={ (el) => this.nav = el }
                        blockTypes={ blockTypes }
                        onAdd={ this._onAdd }
                        onExit={ this.close } />)

--- a/src/components/__tests__/Block.test.jsx
+++ b/src/components/__tests__/Block.test.jsx
@@ -33,7 +33,7 @@ describe('Components - Block', function() {
   })
 
   it ('sends an onOpen callback to the menu it owns', function() {
-    component.refs.menu.props.onOpen()
+    component.menu.props.onOpen()
     component.state.should.have.property('menuOpen', true)
   })
 
@@ -43,20 +43,20 @@ describe('Components - Block', function() {
   })
 
   it ('passes menu items from the block type component to the menu', function() {
-    let { menu } = component.refs
+    let { menu } = component
     component.setState({ menuOpen: true })
-    menu.refs.should.have.property('test')
+    menu.should.have.property('test')
   })
 
   it ('can close a menu', function() {
-    let { menu } = component.refs
+    let { menu } = component
     component.setState({ menuOpen: true })
     menu.props.onExit()
     component.state.menuOpen.should.equal(false)
   })
 
   it ('respects default the content prop', function() {
-    let block = component.refs.block
+    let { block } = component
 
     expect(block.props.content.text).to.equal('Test')
   })

--- a/src/components/__tests__/BlockMenu.test.jsx
+++ b/src/components/__tests__/BlockMenu.test.jsx
@@ -28,20 +28,20 @@ describe('Components - BlockMenu', function() {
 
   it ('calls the onOpen property when the handle is clicked', function() {
     let test = render(menu)
-    TestUtils.Simulate.click(DOM.findDOMNode(test.refs.handle))
+    TestUtils.Simulate.click(DOM.findDOMNode(test.handle))
     menu.props.onOpen.should.have.been.called
   })
 
   it ('can add new menu items', function() {
     let test = render(React.cloneElement(menu, { items: [{ id: 'test', label: 'Test'}] }))
-    test.refs.should.have.property('test')
+    test.should.have.property('test')
   })
 
   it ('calls the destroy action', function() {
     let test  = render(menu)
     let block = test.props.block
 
-    TestUtils.Simulate.click(DOM.findDOMNode(test.refs.destroy))
+    TestUtils.Simulate.click(DOM.findDOMNode(test.destroy))
 
     app.push.should.have.been.calledWith(Actions.destroy, block.id)
   })
@@ -50,21 +50,21 @@ describe('Components - BlockMenu', function() {
     let block = app.state.blocks.concat().pop()
     let test  = render(React.cloneElement(menu, { block }))
 
-    TestUtils.Simulate.click(DOM.findDOMNode(test.refs.moveBefore))
+    TestUtils.Simulate.click(DOM.findDOMNode(test.moveBefore))
 
     app.push.should.have.been.calledWith(Actions.move, [block, -1])
   })
 
   it ('disables Move Before if the block is the first child', function() {
     let test = render(menu)
-    test.refs.moveBefore.isDisabled().should.equal(true)
+    test.moveBefore.isDisabled().should.equal(true)
   })
 
   it ('moves a block down when Move After is clicked', function() {
     let block = app.state.blocks[0]
     let test  = render(React.cloneElement(menu, { block }))
 
-    TestUtils.Simulate.click(DOM.findDOMNode(test.refs.moveAfter))
+    TestUtils.Simulate.click(DOM.findDOMNode(test.moveAfter))
 
     app.push.should.have.been.calledWith(Actions.move, [block, 1])
   })
@@ -73,6 +73,6 @@ describe('Components - BlockMenu', function() {
     let block = app.state.blocks.concat().pop()
     let test  = render(React.cloneElement(menu, { block }))
 
-    test.refs.moveAfter.isDisabled().should.equal(true)
+    test.moveAfter.isDisabled().should.equal(true)
   })
 })

--- a/src/components/__tests__/Switch.test.jsx
+++ b/src/components/__tests__/Switch.test.jsx
@@ -111,7 +111,7 @@ describe('Components - Switch', function() {
       let base = render(<Switch app={ app } />)
 
       base.setState({ open: true })
-      TestUtils.Simulate.keyUp(DOM.findDOMNode(base.refs.nav), { key: 'Escape' })
+      TestUtils.Simulate.keyUp(DOM.findDOMNode(base.nav), { key: 'Escape' })
       base.state.open.should.equal(false)
     })
 
@@ -119,7 +119,7 @@ describe('Components - Switch', function() {
       let base = render(<Switch app={ app } />)
 
       base.setState({ open: true })
-      TestUtils.Simulate.keyUp(DOM.findDOMNode(base.refs.nav), { key: 'q' })
+      TestUtils.Simulate.keyUp(DOM.findDOMNode(base.nav), { key: 'q' })
       base.state.open.should.equal(true)
     })
   })


### PR DESCRIPTION
In React 15, warnings are now in place for legacy string refs in certain places. What I see on CK with 15.6.0:

> Warning: string refs are not supported on children of TransitionGroup and will be ignored. Please use a callback ref instead

This change moves all string refs to the callback pattern to be more future-friendly.