### PR TITLE
Remove uid package

### DIFF
--- a/addons/common/field.jsx
+++ b/addons/common/field.jsx
@@ -4,7 +4,11 @@
  */
 
 let React = require('react')
-let uid   = require('uid')
+
+function uid(len) {
+  len = len || 7;
+  return Math.random().toString(35).substr(2, len);
+}
 
 let Field = React.createClass({
 

--- a/package.json
+++ b/package.json
@@ -88,8 +88,7 @@
     "microcosm": "~9.21",
     "react-addons-css-transition-group": ">= 0.14",
     "react-focus-trap": "~2.3",
-    "react-ink": "~5.1",
-    "uid": "0.0.2"
+    "react-ink": "~5.1"
   },
   "babel": {
     "stage": 2,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4115,10 +4115,6 @@ uid-number@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/uid-number/-/uid-number-0.0.6.tgz#0ea10e8035e8eb5b8e4449f06da1c730663baa81"
 
-uid@0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/uid/-/uid-0.0.2.tgz#5e4a5d4b78138b4f70f89fd3c76fc59aa9d2f103"
-
 ultron@1.0.x:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/ultron/-/ultron-1.0.2.tgz#ace116ab557cd197386a4e88f4685378c8b2e4fa"


### PR DESCRIPTION
The uid package is no longer maintained. We use this package to
generate unique ids for the <Field /> component's labels.

This commit inlines that code, which is only three lines of code.

Fixes #131