### PR TITLE
Allow MenuItem label to be a function

### DIFF
--- a/docs/menus.md
+++ b/docs/menus.md
@@ -71,9 +71,9 @@ Another example:
 ```javascript
 getMenuItems() {
   return [{
-    id         : 'hello-world',
-    label      : () => `Toggle position: ${this.positionLabel()}`
-    onClick    : () => this.togglePosition()
+    id      : 'hello-world',
+    label   : () => `Toggle position: ${this.positionLabel()}`
+    onClick : () => this.togglePosition()
   }]
 }
 ```

--- a/docs/menus.md
+++ b/docs/menus.md
@@ -48,7 +48,7 @@ There are several things going on here:
 1.  The UI for new menu items is described in the `getMenuItems` method
 2.  Whenever a menu item is clicked, it will execute the `onClick` option
 
-## onClick and isDisabled
+## onClick, label, and isDisabled
 
 Menu items can also define an `onClick` and `isDisabled` field. Both
 of these should be functions and are passed the specific editor and
@@ -59,8 +59,21 @@ getMenuItems() {
   return [{
     id         : 'hello-world',
     label      : 'Hello World',
+    label      : (editor, block, menuItem) => `My special block ${block.id}`,
     onClick    : (editor, block, menuItem) => alert(`My block is ${ block.id }`),
     isDisabled : (editor, block, menuItem) => false
+  }]
+}
+```
+
+Another example:
+
+```javascript
+getMenuItems() {
+  return [{
+    id         : 'hello-world',
+    label      : () => `Toggle position: ${this.positionLabel()}`
+    onClick    : () => this.togglePosition()
   }]
 }
 ```

--- a/src/components/MenuItem.js
+++ b/src/components/MenuItem.js
@@ -39,8 +39,9 @@ export default class MenuItem extends React.Component {
   }
 
   _formatLabel(label) {
+    let { app, block } = this.props
     if (typeof label === 'function') {
-      return label.call()
+      return label(app, block, this)
     } else {
       return label
     }

--- a/src/components/MenuItem.js
+++ b/src/components/MenuItem.js
@@ -33,9 +33,17 @@ export default class MenuItem extends React.Component {
         onClick={this._onClick.bind(this)}
         disabled={this.isDisabled()}
       >
-        {label}
+        {this._formatLabel(label)}
       </Button>
     )
+  }
+
+  _formatLabel(label) {
+    if (typeof label === 'function') {
+      return label.call()
+    } else {
+      return label
+    }
   }
 
   _onClick() {

--- a/src/components/__tests__/MenuItem.test.js
+++ b/src/components/__tests__/MenuItem.test.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import DOM from 'react-dom'
 import Colonel from '../../Colonel'
 import Item from '../MenuItem'
 import config from './fixtures/colonelConfig'
@@ -26,6 +27,17 @@ describe('Components - Menu Item', function() {
     let item = render(<Item app={app} block={block} id="id" label="test" />)
 
     expect(item.props.isDisabled()).not.toBeDefined()
+  })
+
+  it('allows label to be a function', function() {
+    const block = app.state.blocks[0]
+    const label = function() {
+      return 'my-label'
+    }
+    const item = render(<Item app={app} block={block} id="id" label={label} />)
+    const result = DOM.findDOMNode(item)
+
+    expect(result.textContent).toEqual('my-label')
   })
 
   it('sends the item component into the onClick callback', function(done) {

--- a/src/components/__tests__/MenuItem.test.js
+++ b/src/components/__tests__/MenuItem.test.js
@@ -34,7 +34,9 @@ describe('Components - Menu Item', function() {
     const labelFn = function() {
       return 'my-label'
     }
-    const item = render(<Item app={app} block={block} id="id" label={labelFn} />)
+    const item = render(
+      <Item app={app} block={block} id="id" label={labelFn} />
+    )
     const result = DOM.findDOMNode(item)
 
     expect(result.textContent).toEqual('my-label')

--- a/src/components/__tests__/MenuItem.test.js
+++ b/src/components/__tests__/MenuItem.test.js
@@ -31,10 +31,10 @@ describe('Components - Menu Item', function() {
 
   it('allows label to be a function', function() {
     const block = app.state.blocks[0]
-    const label = function() {
+    const labelFn = function() {
       return 'my-label'
     }
-    const item = render(<Item app={app} block={block} id="id" label={label} />)
+    const item = render(<Item app={app} block={block} id="id" label={labelFn} />)
     const result = DOM.findDOMNode(item)
 
     expect(result.textContent).toEqual('my-label')


### PR DESCRIPTION
# Problem
I'd like to pass a function to the label prop that will dynamically generate the menu item text. Currently, the menu item label can only be set statically and doesn't get re-rendered when the properties of my component block changes.

# Solution
In MenuItem, check if the label is a function, and if so call it and return the result as the text in the button.