### PR TITLE
[WIP] Add `blockTypesData` for additional props.

### DIFF
--- a/addons/youtube/index.js
+++ b/addons/youtube/index.js
@@ -28,6 +28,8 @@ export default class YouTube extends React.Component {
   render() {
     const { baseUrl, content } = this.props
 
+    console.log(this.props.name)
+
     return (
       <Embedded
         className="col-youtube"

--- a/example/example.js
+++ b/example/example.js
@@ -52,6 +52,11 @@ const blockTypes = [
 let editor = new ColonelKurtz({
   el: document.getElementById('app'),
   blockTypes: blockTypes,
+  blockTypesData: {
+    youtube: {
+      name: 'Chris'
+    }
+  },
   maxChildren: 5,
   maxDepth: 3
 })

--- a/src/components/Block.js
+++ b/src/components/Block.js
@@ -59,10 +59,15 @@ export default class Block extends React.PureComponent {
     return assign({}, defaults.content, block.content)
   }
 
+  getBlockTypeData(block) {
+    return this.getBlockType()['data'] || {}
+  }
+
   render() {
     let { app, block, children } = this.props
     let { component: Component } = this.getBlockType()
     let { menuOpen, extraMenuItems } = this.state
+    let data = this.getBlockTypeData(block)
 
     // Determine content by taking the default content and extend it with
     // the current block content
@@ -74,6 +79,7 @@ export default class Block extends React.PureComponent {
           <Component
             ref={el => (this.block = el)}
             {...block}
+            {...data}
             content={content}
             onChange={this._onChange.bind(this)}
           >

--- a/src/plugins/bootstrap.js
+++ b/src/plugins/bootstrap.js
@@ -15,6 +15,16 @@ let parseElement = function(element) {
   return data
 }
 
+let injectData = function(blockTypes, data) {
+  return blockTypes.map(config => {
+    let { id } = config
+    if (data[id]) {
+      config['data'] = data[id]
+    }
+    return config
+  })
+}
+
 export default {
   filter(blockTypes, acceptable) {
     if (!acceptable) return blockTypes
@@ -24,19 +34,28 @@ export default {
 
   register(
     app,
-    { allow, maxChildren = Infinity, blocks, blockTypes, maxDepth = Infinity },
+    {
+      allow,
+      maxChildren = Infinity,
+      blocks,
+      blockTypes,
+      blockTypesData = {},
+      maxDepth = Infinity
+    },
     next
   ) {
     if (blocks instanceof HTMLElement) {
       blocks = parseElement(blocks)
     }
 
+    blockTypes = injectData(this.filter(blockTypes, allow), blockTypesData)
+
     app.replace(
       {
         maxChildren,
         maxDepth,
         blocks,
-        blockTypes: this.filter(blockTypes, allow)
+        blockTypes
       },
       next
     )


### PR DESCRIPTION
Specify (optional) blockType-specific data to pass
as props on render.

# Motivation

Imagine a component that selects from a list:

```
{
  id: 'animals',
  label: 'Animals',
  component: Animals
}
```

You use 'animals' in many places. But then a new 
component request comes in: it should be similar 
to  'animals', but filter results to show only 
warm-blooded animals. 

Now you could create a brand new
blockType, and that might be appropriate in 
certain situations. But in many cases, it would be 
simpler to reuse component logic with props.

# Proposal

Use a new bootstrap options key, `blockTypesData`,
as a map of `blockType.id` keys. The value for
each key is an object, which becomes a part of the
`BlockType` as `data` and spread as props for the
component.

I'm open to approaching this in other ways. This 
is a first pass that I hope helps communicate 
the end goal.