### PR TITLE
Automatically generate labels on fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 5.1.0
+
+- Generate a unique ID for <Field /> and its associated label.
+
 ## 5.0.2
 
 - Fix build issue where Object.assign compiled to `true`

--- a/addons/common/__tests__/field.test.js
+++ b/addons/common/__tests__/field.test.js
@@ -33,4 +33,22 @@ describe('Addons - Common - Field', function() {
 
     expect(hint.id).toEqual(input.getAttribute('aria-describedby'))
   })
+
+  it('sets up a unique id', function() {
+    let component = render(<Field />)
+    let label = DOM.findDOMNode(component)
+    let input = label.querySelector('.col-field-input')
+
+    expect(input.hasAttribute('id')).toBe(true)
+    expect(label.getAttribute('for')).toEqual(input.id)
+  })
+
+  it('respects a given id attribute', function() {
+    let component = render(<Field id="test" />)
+    let label = DOM.findDOMNode(component)
+    let input = label.querySelector('.col-field-input')
+
+    expect(input.getAttribute('id')).toBe('test')
+    expect(label.getAttribute('for')).toEqual(input.id)
+  })
 })

--- a/addons/common/field.js
+++ b/addons/common/field.js
@@ -19,17 +19,12 @@ const defaultProps = {
 }
 
 export default class Field extends React.Component {
-  constructor() {
-    super(...arguments)
-
-    this.state = {
-      hintId: `hint-col-field-${uid()}`
-    }
-  }
+  fieldId = `col-field-${uid()}`
+  hintId = `${this.fieldId}-hint`
 
   getHint(hint) {
     return hint ? (
-      <span id={this.state.hintId} className="col-field-hint">
+      <span id={this.hintId} className="col-field-hint">
         {hint}
       </span>
     ) : null
@@ -37,16 +32,18 @@ export default class Field extends React.Component {
 
   render() {
     let { hint, element: Element, label, ...props } = this.props
-    let { hintId } = this.state
+
+    let id = 'id' in props ? props.id : this.fieldId
 
     return (
-      <label className="col-field">
+      <label className="col-field" htmlFor={id}>
         <span className="col-field-label">{label}</span>
 
         <Element
           ref={el => (this.input = el)}
+          id={id}
           className="col-field-input"
-          aria-describedby={hint ? hintId : null}
+          aria-describedby={hint ? this.hintId : null}
           {...props}
         />
         {this.getHint(hint)}


### PR DESCRIPTION
When a field is not given an id, automatically generate a wired up label for the field addon.

I noticed this doing some integration work. We were putting the logic in place to setup a unique ID for its  own sake. We can just do this under the hood.