### PR TITLE
Add a more ergonomic way to set fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## 5.1.0
 
-- Generate a unique ID for <Field /> and its associated label.
+- Generate a unique ID for <Field /> and its associated label
+- Content may now be updated by passing a key/value pair to `onChange`, like: `this.props.onChange('key', 'value')`
 
 ## 5.0.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,36 @@
 ## 5.1.0
 
 - Generate a unique ID for <Field /> and its associated label
-- Content may now be updated by passing a key/value pair to `onChange`, like: `this.props.onChange('key', 'value')`
+- Content may now be updated by passing a key/value pair to
+  `onChange`. See the following section for more info.
+
+### Content may now be updated by passing a key/value pair
+
+We've hit many situations where we need to update a deeply nested key
+in CK. This is particularly painful when updating an index of an
+array:
+
+```javascript
+let tags = this.props.metadata.tags.concat()
+
+tags[1] = 'jellybeans'
+
+this.props.onChange({
+  metadata: { ...this.props.content.metadata, tags }
+})`
+```
+
+Instead, with this release you can provide a key path. This behaves
+similarly to [Lodash's set function](https://lodash.com/docs#set):
+
+```
+this.props.onChange('title', 'My Dessert Foods')
+this.props.onChange('metadata.tags.1', 'jellybeans')
+```
+
+By providing a string of `dot` separated values, CK will drill down
+into content properties on your behalf. This aims to greatly improve
+the ergonomics of updating nested keys.
 
 ## 5.0.2
 

--- a/addons/youtube/index.js
+++ b/addons/youtube/index.js
@@ -42,7 +42,7 @@ export default class YouTube extends React.Component {
   }
 
   _onChange({ video_id }) {
-    this.props.onChange({ video_id: parseYouTube(video_id) })
+    this.props.onChange('video_id', parseYouTube(video_id))
   }
 }
 

--- a/addons/youtube/index.js
+++ b/addons/youtube/index.js
@@ -42,7 +42,7 @@ export default class YouTube extends React.Component {
   }
 
   _onChange({ video_id }) {
-    this.props.onChange('video_id', parseYouTube(video_id))
+    this.props.onChange({ video_id: parseYouTube(video_id) })
   }
 }
 

--- a/docs/blockTypes.md
+++ b/docs/blockTypes.md
@@ -54,6 +54,8 @@ class TextBook extends React.Component {
   }
 
   _onBlur(e) {
+    // Alternatively,
+    // this.props.onChange('text', e.currentTarget.textContent)
     this.props.onChange({
       text: e.currentTarget.textContent
     })

--- a/docs/blockTypes.md
+++ b/docs/blockTypes.md
@@ -4,6 +4,7 @@
 2.  [Properties](#properties)
 3.  [Creating Block Types](#creating-block-types)
 4.  [Advanced Block Types](#advanced-block-types)
+5.  [Updating content](#updating-content)
 
 ## Overview
 
@@ -102,3 +103,37 @@ let blockTypes = [
   }
 ]
 ```
+
+## Updating content
+
+Each block type is passed an `onChange` property. You can use this property to signal changes to the `content` field for a given block.
+
+There are two ways to update content: provide an object, or a key path and value.
+
+### Updating content with an object
+
+Passing an object into the `onChange` prop will merge the fields provided into the existing content block:
+
+```javascript
+changeText(text) {
+  this.props.onChange({ text })
+}
+```
+
+### Updating content with a key path and value
+
+By providing a key path and value, Colonel Kurtz update a specific key within the shape of your content. This is particularly useful for updating nested keys.
+
+This behaves similarly to [Lodash's set function](https://lodash.com/docs#set):
+
+```javascript
+changeText(text) {
+  this.props.onChange('text', text)
+  // { text: text }
+
+  this.props.onChange('deeply.nested.key', true)
+  // { deeply: { nested: { key: true } } }
+}
+```
+
+By providing a string of `dot` separated values, CK will drill down into content properties on your behalf. This aims to greatly improve the ergonomics of updating nested keys.

--- a/src/actions/blocks.js
+++ b/src/actions/blocks.js
@@ -13,6 +13,10 @@ export default {
     return { id: id.valueOf(), content }
   },
 
+  set(id, path, value) {
+    return { id: id.valueOf(), path, value }
+  },
+
   move(block, distance) {
     return { block, distance }
   }

--- a/src/components/Block.js
+++ b/src/components/Block.js
@@ -97,8 +97,16 @@ export default class Block extends React.PureComponent {
     )
   }
 
-  _onChange(content) {
+  _onChange(keypath, value) {
     let { app, block } = this.props
-    app.push(Actions.update, [block, content])
+
+    if (typeof keypath === 'object') {
+      // onChange({ field: 'value' })
+      app.push(Actions.update, [block, keypath])
+    } else {
+      // onChange('field', 'value')
+      // onChange('deep.field', 'value')
+      app.push(Actions.set, [block, keypath, value])
+    }
   }
 }

--- a/src/stores/Blocks.js
+++ b/src/stores/Blocks.js
@@ -13,7 +13,7 @@ import insertAt from '../utils/insertAt'
 import siblingAt from '../utils/siblingAt'
 import blocksToJson from '../utils/blocksToJson'
 import jsonToBlocks from '../utils/jsonToBlocks'
-import { assign } from '../utils/data'
+import { assign, set } from '../utils/data'
 
 const Blocks = {
   register() {
@@ -21,6 +21,7 @@ const Blocks = {
       [Actions.create]: this.create,
       [Actions.destroy]: this.destroy,
       [Actions.update]: this.update,
+      [Actions.set]: this.set,
       [Actions.move]: this.move
     }
   },
@@ -85,6 +86,14 @@ const Blocks = {
     var block = Blocks.find(state, id)
 
     block.content = assign({}, block.content, content)
+
+    return state
+  },
+
+  set(state, { id, path, value }) {
+    var block = Blocks.find(state, id)
+
+    block.content = set(block.content, path, value)
 
     return state
   },

--- a/src/stores/__tests__/Blocks.test.js
+++ b/src/stores/__tests__/Blocks.test.js
@@ -42,6 +42,19 @@ describe('Stores - Block', function() {
     expect(target.content).toHaveProperty('foo', 'bar')
   })
 
+  it('can set a nested key for a block', function() {
+    let target = new Block({})
+    let initial = [new Block({}), target, new Block({})]
+
+    Blocks.set(initial, {
+      id: target.id,
+      path: 'foo.bar',
+      value: 'baz'
+    })
+
+    expect(target.content.foo.bar).toBe('baz')
+  })
+
   it('can move a block', function() {
     let target = new Block({})
     let next = new Block({})

--- a/src/utils/__tests__/data.test.js
+++ b/src/utils/__tests__/data.test.js
@@ -1,0 +1,160 @@
+import { get, set } from '../data'
+
+describe('data', function() {
+  describe('set', function() {
+    const subject = {
+      styles: {
+        color: 'blue',
+        font: 'Helvetica, sans-serif'
+      }
+    }
+
+    it('can set a single key', function() {
+      let next = set(subject, 'styles', false)
+
+      expect(next.styles).toEqual(false)
+    })
+
+    it('can assign an empty path', function() {
+      let value = set(subject, [], false)
+
+      expect(value).toBe(false)
+    })
+
+    it('assigns undefined', function() {
+      let next = set(subject, 'styles', undefined)
+
+      expect(next.styles).toEqual(undefined)
+    })
+
+    it('can set a deep key', function() {
+      let next = set(subject, ['styles', 'color'], 'red')
+
+      expect(next.styles.color).toEqual('red')
+    })
+
+    it('can set a deep key using dot notation', function() {
+      let next = set(subject, 'styles.color', 'red')
+
+      expect(next.styles.color).toEqual('red')
+    })
+
+    it('can set new keys deeply', function() {
+      let next = set(subject, ['styles', 'padding', 'top'], 10)
+
+      expect(next.styles.padding.top).toEqual(10)
+    })
+
+    it('does not destructively update data', function() {
+      let next = set(subject, ['styles', 'padding', 'top'], 10)
+
+      expect(next).not.toBe(subject)
+      expect(next.styles).not.toBe(subject.styles)
+      expect(next.styles.padding).not.toBe(subject.styles.padding)
+    })
+
+    it('does not duplicate objects when the value is the same', function() {
+      let next = set(subject, ['styles', 'color'], 'blue')
+
+      expect(next).toBe(subject)
+      expect(next.styles).toBe(subject.styles)
+    })
+
+    it('does modify the original value', function() {
+      let next = set(subject, ['styles', 'color'], 'red')
+
+      expect(subject.styles.color).toBe('blue')
+      expect(next.styles.color).toBe('red')
+    })
+
+    it('assigns over an existing nested object', function() {
+      let next = set({ root: true }, ['root', 'segment'], true)
+
+      expect(next.root).toEqual({ segment: true })
+    })
+
+    describe('arrays', function() {
+      it('can operate on arrays', function() {
+        let list = ['a', 'b', 'c']
+        let next = set(list, 3, 'd')
+
+        expect(Array.isArray(next)).toBe(true)
+        expect(next[3]).toBe('d')
+      })
+
+      it('properly assigns nested arrays', function() {
+        let list = { a: ['b', 'c'] }
+        let next = set(list, ['a', 1], 'd')
+
+        expect(next).toEqual({ a: ['b', 'd'] })
+        expect(next['a']).toBeInstanceOf(Array)
+      })
+
+      it('properly assigns nested arrays where keys are missing', function() {
+        let space = { planets: [] }
+        let next = set(space, ['planets', 0, 'color'], 'red')
+
+        expect(next).toEqual({ planets: [{ color: 'red' }] })
+        expect(next['planets']).toBeInstanceOf(Array)
+        expect(next['planets'][0]).toEqual({ color: 'red' })
+      })
+    })
+  })
+
+  describe('get', function() {
+    const subject = {
+      styles: {
+        color: 'blue',
+        font: 'Helvetica, sans-serif'
+      }
+    }
+
+    it('can retrieve a single key', function() {
+      let styles = get(subject, 'styles')
+
+      expect(styles).toEqual(subject.styles)
+    })
+
+    it('can retrieve a deep key path', function() {
+      let color = get(subject, ['styles', 'color'])
+
+      expect(color).toEqual(subject.styles.color)
+    })
+
+    it('returns a fallback if the key is undefined', function() {
+      let padding = get(subject, ['styles', 'padding'], 10)
+
+      expect(padding).toEqual(10)
+    })
+
+    it('returns the fallback if the object is null', function() {
+      let fallback = get(null, ['missing'], true)
+
+      expect(fallback).toBe(true)
+    })
+
+    it('returns the value if there is no fallback and the value is null', function() {
+      let value = get({ prop: null }, 'prop')
+
+      expect(value).toBe(null)
+    })
+
+    it('returns the value if there is no fallback and the value is undefined', function() {
+      let value = get({ prop: undefined }, 'prop')
+
+      expect(value).toBe(undefined)
+    })
+
+    it('returns the fallback if the key and fallback are null', function() {
+      let fallback = get(null, null, true)
+
+      expect(fallback).toBe(true)
+    })
+
+    it('returns the fallback if a mid-way key is null', function() {
+      let fallback = get({ a: { b: null } }, 'a.b.c', true)
+
+      expect(fallback).toBe(true)
+    })
+  })
+})

--- a/src/utils/data.js
+++ b/src/utils/data.js
@@ -1,3 +1,13 @@
+const KEY_DELIMETER = '.'
+
+function isBlank(value) {
+  return value === '' || value === null || value === undefined
+}
+
+function isObject(target) {
+  return !(!target || typeof target !== 'object')
+}
+
 function copyOver(next, obj) {
   for (var key in obj) {
     next[key] = obj[key]
@@ -6,6 +16,105 @@ function copyOver(next, obj) {
   return next
 }
 
+export function castPath(value) {
+  if (Array.isArray(value)) {
+    return value
+  } else if (isBlank(value)) {
+    return []
+  }
+
+  return typeof value === 'string' ? value.trim().split(KEY_DELIMETER) : [value]
+}
+
 export function assign(subject, ...values) {
   return values.reduce(copyOver, subject)
+}
+
+/**
+ * Shallow copy an object
+ */
+export function clone(target) {
+  if (Array.isArray(target)) {
+    return target.slice(0)
+  } else if (isObject(target) === false) {
+    return {}
+  }
+
+  let copy = {}
+
+  for (var key in target) {
+    copy[key] = target[key]
+  }
+
+  return copy
+}
+
+/**
+ * Retrieve a value from an object. If no key is provided, just return
+ * the object.
+ */
+export function get(object, keyPath, fallback) {
+  let path = castPath(keyPath)
+  let value = object
+
+  for (var i = 0, len = path.length; i < len; i++) {
+    if (value == null) {
+      break
+    }
+
+    value = value[path[i]]
+  }
+
+  if (value === undefined || value === null) {
+    return arguments.length <= 2 ? value : fallback
+  }
+
+  return value
+}
+
+/**
+ * Non-destructively assign a value to a provided object at a given key. If the
+ * value is the same, don't do anything. Otherwise return a new object.
+ */
+export function set(object, key, value) {
+  // Ensure we're working with a key path, like: ['a', 'b', 'c']
+  let path = castPath(key)
+
+  let len = path.length
+
+  if (len <= 0) {
+    return value
+  }
+
+  if (get(object, path) === value) {
+    return object
+  }
+
+  let root = clone(object)
+  let node = root
+
+  // For each key in the path...
+  for (var i = 0; i < len; i++) {
+    let key = path[i]
+    let next = value
+
+    // Are we at the end?
+    if (i < len - 1) {
+      // No: Check to see if the key is already assigned,
+      if (key in node) {
+        // If yes, clone that value
+        next = clone(node[key])
+      } else {
+        // Otherwise assign an object so that we can keep drilling down
+        next = {}
+      }
+    }
+
+    // Assign the value, then continue on to the next iteration of the loop
+    // using the next step down
+    node[key] = next
+    node = node[key]
+  }
+
+  return root
 }


### PR DESCRIPTION
Our Colonel Kurtz custom block code is plagued with very complex data
operations. Particularly for nested keys.

This commit adds a new way to set data: a key path. By providing a key
path and value, a user can deeply update an existing key immutably:

```javascript
this.props.onChange('settings.visible', true)
```