### PR TITLE
Use regex instead of DOM traversal to sanitize embeds

### DIFF
--- a/addons/html-embed/__tests__/html-embed.test.js
+++ b/addons/html-embed/__tests__/html-embed.test.js
@@ -91,6 +91,24 @@ describe('Addons - HTML Embed', function() {
             target: { value: content }
           })
         })
+
+        it('keeps script tags when set to unsafe', function(done) {
+          function didKeepTags(content) {
+            expect(content.html).toContain('<style')
+            expect(content.html).toContain('<script')
+            done()
+          }
+
+          var component = render(
+            <HtmlEmbed safe={false} onChange={didKeepTags} />
+          )
+          var content =
+            '<style>body{}</style><p>Test</p><script>var three = 2 + 1;</script>'
+
+          Simulate.change(component.html.input, {
+            target: { value: content }
+          })
+        })
       })
     })
   })

--- a/addons/html-embed/index.js
+++ b/addons/html-embed/index.js
@@ -11,7 +11,8 @@ const defaultProps = {
   content: {
     html: '',
     script: ''
-  }
+  },
+  safe: true
 }
 
 export default class HtmlEmbedBlock extends React.Component {
@@ -63,7 +64,13 @@ export default class HtmlEmbedBlock extends React.Component {
   }
 
   onHTMLChange(event) {
-    this.props.onChange({ html: sanitize(event.target.value) })
+    let html = event.target.value
+
+    if (this.props.safe) {
+      html = sanitize(html)
+    }
+
+    this.props.onChange({ html })
   }
 }
 

--- a/addons/html-embed/sanitize.js
+++ b/addons/html-embed/sanitize.js
@@ -1,13 +1,6 @@
-const toArray = list => Array.prototype.slice.call(list)
+let scriptTags = /<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi
+let styleTags = /<style\b[^<]*(?:(?!<\/style>)<[^<]*)*<\/style>/gi
 
 export function sanitize(html) {
-  let bucket = document.createElement('div')
-
-  bucket.innerHTML = html
-
-  let doNotAllow = toArray(bucket.querySelectorAll('script, style'))
-
-  doNotAllow.forEach(el => el.parentNode.removeChild(el))
-
-  return bucket.innerHTML
+  return html.replace(scriptTags, '').replace(styleTags, '')
 }


### PR DESCRIPTION
Problem:

Typing HTML into the HTML embed content block turns carrot symbols
into HTML entities. This makes it impossible to type HTML into the
embed.

Solution:

Instead of traversing the DOM, sanitizing occurs with a regular
expression. This allows more flexible content entry. Additionally it
adds a flag to turn this behavior off in case it becomes a problem.