### PR TITLE
Remove unused onExit callback

### DIFF
--- a/src/components/Switch.js
+++ b/src/components/Switch.js
@@ -48,7 +48,6 @@ export default class Switch extends React.Component {
         ref={el => (this.nav = el)}
         blockTypes={blockTypes}
         onAdd={this._onAdd.bind(this)}
-        onExit={this.close.bind(this)}
       />
     )
   }


### PR DESCRIPTION
Looks like we didn't clean everything up when we removed a focus trap around the
SwitchNav.

Related issues:
https://github.com/vigetlabs/colonel-kurtz/issues/151